### PR TITLE
update: Document LAGO_DISABLE_SIGNUP env variable

### DIFF
--- a/docs/guide/02_self-hosting/docker.md
+++ b/docs/guide/02_self-hosting/docker.md
@@ -82,6 +82,7 @@ Lago uses the following environment variables to configure the components of the
 | LAGO_AWS_S3_REGION | | AWS S3 Region |
 | LAGO_AWS_S3_BUCKET | | AWS S3 Bucket name |
 | LAGO_PDF_URL | http://pdf:3000 | PDF Service URL on your infrastructure |
+| LAGO_DISABLE_SIGNUP | | Disable Sign up when running Lago in self-hosted |
 
 :::caution
 We recommend that you change `POSTGRES_PASSWORD`, `SECRET_KEY_BASE`, `LAGO_RSA_PRIVATE_KEY`, `LAGO_ENCRYPTION_PRIMARY_KEY`, `LAGO_ENCRYPTION_DETERMINISTIC_KEY` and `LAGO_ENCRYPTION_KEY_DERIVATION_SALT` to improve the security of your Lago instance:


### PR DESCRIPTION
## Context

Following https://github.com/getlago/lago/issues/47 issue, a change has been introduced in [lago-front](https://github.com/getlago/lago-front/pull/236) to add a new environment variable to disable the Sign-up page

## Change

This change adds the documentation of `LAGO_DISABLE_SIGNUP` environment variable

Related to https://github.com/getlago/lago/pull/73