### PR TITLE
fix: Update lago documentation url

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "index_name": "lago-docs",
   "start_urls": [
-    "https://doc.getlago.com/docs/guide/intro",
+    "https://doc.getlago.com/docs/guide/intro/welcome",
     "https://doc.getlago.com/docs/guide/self-hosting/docker",
     "https://doc.getlago.com/docs/guide/self-hosting/tracking",
     "https://doc.getlago.com/docs/guide/lago-cloud",
@@ -49,7 +49,7 @@
     "https://doc.getlago.com/docs/api/subscriptions/terminate-subscription",
 
     "https://doc.getlago.com/docs/api/events",
-    
+
     "https://doc.getlago.com/docs/api/coupons/coupon-object",
     "https://doc.getlago.com/docs/api/coupons/create-coupon",
     "https://doc.getlago.com/docs/api/coupons/update-coupon",


### PR DESCRIPTION
## Context

Root URL of the Lago documentation has been updated from https://doc.getlago.com/docs/guide/intro to https://doc.getlago.com/docs/guide/intro/welcome in [this commit](https://github.com/getlago/lago-docs/commit/e7e99d7762b0e0d4548ccec3e78bee0d522e35da).

## Description

The goal of this PR is to update links to the Lago official documentation on this repo.
