### PR TITLE
feat(persisted-metrics): Document event properties

### DIFF
--- a/docs/api/06_events/create-batch-event.mdx
+++ b/docs/api/06_events/create-batch-event.mdx
@@ -29,15 +29,15 @@ api/v1/events/batch
   --header "Authorization: Bearer $API_KEY" \
   --header 'Content-Type: application/json' \
   --data-raw '{
-        "event": { 
+        "event": {
             "transaction_id": "__UNIQUE_ID__",
             "subscription_ids": ["id1", "id2"],
-            "code": "__EVENT_CODE__", 
-            "timestamp": $(date +%s), 
-            "properties": { 
-              "custom_field": 12 
+            "code": "__EVENT_CODE__",
+            "timestamp": $(date +%s),
+            "properties": {
+              "custom_field": 12
             }
-        } 
+        }
     }'
   ```
 
@@ -130,7 +130,16 @@ api/v1/events/batch
 | **customer_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Customer unique identifier in your application |
 | **code** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Code identifying the type of the event.<br></br> It should match the `code` property of one of your active billable metrics, otherwise it will be ignored |
 | **timestamp** | Integer &nbsp &nbsp &nbsp<Optional>**Optional**</Optional><br></br><Comment>*Default: event reception timestamp*</Comment> | Unix timestamp of the event occurence in UTC.<br></br> If not provided, the API will set the event reception time |
-| **properties** | JSON &nbsp &nbsp &nbsp<Variable>**Variable**</Variable> | Extra data to use for the event aggregation.<br></br>When mandatory, it should contains the `field_name` configured at billable metric level as `key` and any value as field `value`.<br></br><details><summary>**Aggregation type:**</summary><div>- `COUNT`: **optional**<br></br>- `MAX`: **required**. value must be an integer<br></br>- `SUM`: **required**. value must be an integer<br></br>- `COUNT UNIQUE`: **required**. value could have any datatype<div></div></div></details> |
+| **properties** | JSON &nbsp &nbsp &nbsp<Variable>**Variable**</Variable> | Extra data to use for the event aggregation.<br></br>When mandatory, it should contains the `field_name` configured at billable metric level as `key` and any value as field `value`.<br></br><details><summary>**Aggregation type:**</summary><div>- `COUNT`: **optional**<br></br>- `MAX`: **required**. value must be an integer<br></br>- `SUM`: **required**. value must be an integer<br></br>- `COUNT UNIQUE`: **required**. value could have any datatype<br></br>- `RECURRING COUNT`: **required**. value must be the unique identifier of the persisted object.<div></div></div></details> |
+
+### Recurring count aggregation
+
+Content of the event `properties` field:
+
+| Attributes | Types | Description |
+|--|--|--|
+| *field_name* **(*)** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | **(*)** Key must be the `field_name` configured at billable metric level and be the unique identifier of the object to persist. |
+| **operation_type** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Type of operation to perform on the persisted object. <details><summary>**Possible values**</summary><div>- `add`: Add or unsuspend a persisted object.<br></br>- `remove`: Remove or suspend a persisted object.</div></details> |
 
 ## Responses
 

--- a/docs/api/06_events/create-batch-event.mdx
+++ b/docs/api/06_events/create-batch-event.mdx
@@ -112,7 +112,7 @@ api/v1/events/batch
 {
   "event": {
     "transaction_id": "__UNIQUE_ID__",
-    "external_customer_id": "__CUSTOMER_ID__",
+    "external_customer_id": "__YOUR_CUSTOMER_ID__",
     "external_subscription_ids": ["id1", "id2"],
     "code": "__EVENT_CODE__",
     "timestamp": 1650893379,
@@ -126,7 +126,7 @@ api/v1/events/batch
 | Attributes | Type | Description |
 | -----------| -----| ----------- |
 | **transaction_id** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Unique ID identifying the event. <br></br>As it will be used for idempotency, it should be a unique identifier |
-| **external_subscription_ids** | Array &nbsp &nbsp &nbsp<Required>**Required**</Required> | Array of subscription ids that belongs to one customer |
+| **external_subscription_ids** | Array &nbsp &nbsp &nbsp<Required>**Required**</Required> | Array of subscription IDs associated with the customer |
 | **external_customer_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Customer unique identifier in your application |
 | **code** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Code identifying the type of the event.<br></br> It should match the `code` property of one of your active billable metrics, otherwise it will be ignored |
 | **timestamp** | Integer &nbsp &nbsp &nbsp<Optional>**Optional**</Optional><br></br><Comment>*Default: event reception timestamp*</Comment> | Unix timestamp of the event occurence in UTC.<br></br> If not provided, the API will set the event reception time |

--- a/docs/api/06_events/create-batch-event.mdx
+++ b/docs/api/06_events/create-batch-event.mdx
@@ -31,7 +31,7 @@ api/v1/events/batch
   --data-raw '{
         "event": {
             "transaction_id": "__UNIQUE_ID__",
-            "subscription_ids": ["id1", "id2"],
+            "external_subscription_ids": ["id1", "id2"],
             "code": "__EVENT_CODE__",
             "timestamp": $(date +%s),
             "properties": {
@@ -52,7 +52,7 @@ api/v1/events/batch
   client = Client(api_key='__YOUR_API_KEY__')
 
   event = BatchEvent(
-    subscription_ids=["id1", "id2"],
+    external_subscription_ids=["id1", "id2"],
     transaction_id="__UNIQUE_ID__",
     code="code",
     timestamp=1650893379,
@@ -73,7 +73,7 @@ api/v1/events/batch
 
   client.events.batch_create(
     transaction_id: "__UNIQUE_ID__",
-    subscription_ids: ["id1", "id2"],
+    external_subscription_ids: ["id1", "id2"],
     code:  "code",
     timestamp: Time.now.to_i,
     properties: {
@@ -94,7 +94,7 @@ api/v1/events/batch
 
   let event = new BatchEvent({
     transactionId: "__UNIQUE_TRANSACTION_ID__",
-    subscriptionIds: ["id1", "id2"],
+    externalSubscriptionIds: ["id1", "id2"],
     code: "code",
     timestamp: 1650893379,
     properties: {customField: "custom"}
@@ -112,8 +112,8 @@ api/v1/events/batch
 {
   "event": {
     "transaction_id": "__UNIQUE_ID__",
-    "customer_id": "__CUSTOMER_ID__",
-    "subscription_ids": ["id1", "id2"],
+    "external_customer_id": "__CUSTOMER_ID__",
+    "external_subscription_ids": ["id1", "id2"],
     "code": "__EVENT_CODE__",
     "timestamp": 1650893379,
     "properties": {
@@ -126,8 +126,8 @@ api/v1/events/batch
 | Attributes | Type | Description |
 | -----------| -----| ----------- |
 | **transaction_id** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Unique ID identifying the event. <br></br>As it will be used for idempotency, it should be a unique identifier |
-| **subscription_ids** | Array &nbsp &nbsp &nbsp<Required>**Required**</Required> | Array of subscription ids that belongs to one customer |
-| **customer_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Customer unique identifier in your application |
+| **external_subscription_ids** | Array &nbsp &nbsp &nbsp<Required>**Required**</Required> | Array of subscription ids that belongs to one customer |
+| **external_customer_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Customer unique identifier in your application |
 | **code** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Code identifying the type of the event.<br></br> It should match the `code` property of one of your active billable metrics, otherwise it will be ignored |
 | **timestamp** | Integer &nbsp &nbsp &nbsp<Optional>**Optional**</Optional><br></br><Comment>*Default: event reception timestamp*</Comment> | Unix timestamp of the event occurence in UTC.<br></br> If not provided, the API will set the event reception time |
 | **properties** | JSON &nbsp &nbsp &nbsp<Variable>**Variable**</Variable> | Extra data to use for the event aggregation.<br></br>When mandatory, it should contains the `field_name` configured at billable metric level as `key` and any value as field `value`.<br></br><details><summary>**Aggregation type:**</summary><div>- `COUNT`: **optional**<br></br>- `MAX`: **required**. value must be an integer<br></br>- `SUM`: **required**. value must be an integer<br></br>- `COUNT UNIQUE`: **required**. value could have any datatype<br></br>- `RECURRING COUNT`: **required**. value must be the unique identifier of the persisted object.<div></div></div></details> |

--- a/docs/api/06_events/create-event.mdx
+++ b/docs/api/06_events/create-event.mdx
@@ -165,7 +165,16 @@ api/v1/events
 | **customer_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Customer unique identifier in your application.<br></br>If `subscription_id` is not given, `customer_id` is required if there is only one subscription attached to customer. For multiple subscriptions per customer this attribute is not enough |
 | **code** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Code identifying the type of the event.<br></br> It should match the `code` property of one of your active billable metrics, otherwise it will be ignored |
 | **timestamp** | Integer &nbsp &nbsp &nbsp<Optional>**Optional**</Optional><br></br><Comment>*Default: event reception timestamp*</Comment> | Unix timestamp of the event occurence in UTC.<br></br> If not provided, the API will set the event reception time |
-| **properties** | JSON &nbsp &nbsp &nbsp<Variable>**Variable**</Variable> | Extra data to use for the event aggregation.<br></br>When mandatory, it should contains the `field_name` configured at billable metric level as `key` and any value as field `value`.<br></br><details><summary>**Aggregation type:**</summary><div>- `COUNT`: **optional**<br></br>- `MAX`: **required**. value must be an integer<br></br>- `SUM`: **required**. value must be an integer<br></br>- `COUNT UNIQUE`: **required**. value could have any datatype<div></div></div></details> |
+| **properties** | JSON &nbsp &nbsp &nbsp<Variable>**Variable**</Variable> | Extra data to use for the event aggregation.<br></br>When mandatory, it should contains the `field_name` configured at billable metric level as `key` and any value as field `value`.<br></br><details><summary>**Aggregation type:**</summary><div>- `COUNT`: **optional**<br></br>- `MAX`: **required**. value must be an integer<br></br>- `SUM`: **required**. value must be an integer<br></br>- `COUNT UNIQUE`: **required**. value could have any datatype<br></br>- `RECURRING COUNT`: **required**. value must be the unique identifier of the persisted object.<div></div></div></details> |
+
+### Recurring count aggregation
+
+Content of the event `properties` field:
+
+| Attributes | Types | Description |
+|--|--|--|
+| *field_name* **(*)** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | **(*)** Key must be the `field_name` configured at billable metric level and be the unique identifier of the object to persist. |
+| **operation_type** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Type of operation to perform on the persisted object. <details><summary>**Possible values**</summary><div>- `add`: Add or unsuspend a persisted object.<br></br>- `remove`: Remove or suspend a persisted object.</div></details> |
 
 ## Responses
 

--- a/docs/guide/04_billable-metrics/aggregation-types.md
+++ b/docs/guide/04_billable-metrics/aggregation-types.md
@@ -3,60 +3,35 @@ sidebar_position: 2
 ---
 
 # Aggregation Types
-By selecting one of the **aggregation types** for a Billable metric, you define how the ingested events are compiled and calculated at the end of a billable period.
 
-Here is the full list of aggregation types currently supported officially by Lago.
+## Metered aggregation types
+
+By selecting a **metered** aggregation type for a billable metric, the calculated units to be charged are resumed to 0 at the end of each billing period. These aggregation types, listed below, define how the ingested events are compiled and calculated at the end of a billable period.
+
+Here is the full list of **metered aggregation types** currently supported officially by Lago.
 
 | Aggregation | Description                                            | Transcription  |
 | --------    | ------------------------------------------------------ | ------------------------- |
 | **COUNT**   | Count the number of times an incoming event occurs     | `COUNT(event.code)` |
 | **SUM**       | Sum a defined property for incoming events           | `SUM(event.properties.property_name)`
 | **MAX**       | Get the maximum value of a defined property for incoming events              | `MAX(event.properties.property_name)` |
-| **COUNT DISTINCT**  | Get the number of unique value of a defined property for incoming events   |  `COUNT_DISTINCT(event.properties.property_name)` |
+| **COUNT UNIQUE**  | Count the number of unique value of a defined property for incoming events |  `COUNT_DISTINCT(event.properties.property_name)` |
 
 Except the `COUNT`(that is counting the number of times an event occurs), the other types aggregate over a single property of the event. **The result of this aggregation will be used to charge your customers.**
 
-You can find more description and examples below.
+## Persistent aggregation types
 
-:::info
-Note that these aggregation rules are used to calculate usage-based behaviors. 
-Other existing solutions name it `meter` or `metering`.
+By selecting a **persistent aggregation type** for a billable metric, the calculated units to be charged are persisted periods over periods, unless you or your customers decide to change it. This is very useful if you want to build a fair pricing model (ie: per-seat, or per-integration pricing for instance).
+
+Here is the full list of **persistent aggregation types** currently supported officially by Lago.
+
+| Aggregation | Description                                            | Transcription  |
+| --------    | ------------------------------------------------------ | ------------------------- |
+| **RECURRING COUNT**   | Count the number of unique value of a defined property for incoming events, **but persists the value period over period unless you change it**| `ADD(event.properties.property_name)` or  `REMOVE(event.properties.property_name)`|
+
+- **Add**: this `operation_type` adds that item to the units to be charged at the end of the period. You don't need to send the event every billing period to charge your customers. The charge for this item is pro-rated for the first period.
+- **Remove**: this `operation_type` removes that item to the units to be charged at the end of the period. It will not be taken into account for the next billing periods. The charge for this item is pro-rated for the last period.
+
+:::tip
+**Lago automatically created a pro-rated charge based on the number of days consumed by an item during a billing period.** An item that is added is persisted and charged period over period.
 :::
-
-## 1. COUNT
-Count the number of times an incoming event occurs. During a billable period, each time a defined event is flowing in, Lago will increment the final result. At the end of the billable period, this result resumes to 0.
-
-This aggregation rule is very useful when you have to calculate a simple behavior.
-
-`COUNT.event.code`
-
-
-## 2. SUM
-Sum a defined property for incoming events. During a billable period, each time a defined event is flowing in, Lago will sum the defined property. At the end of the billable period, this sum resumes to 0.
-
-This aggregation type is very useful to sum the consumption, such as the *number of pageviews* or the *number of gigabytes used*, for instance.
-
-`SUM(event.properties.property_name)`
-
-:::caution
-As a `SUM` returns a number, the single property you aggregate on **must be numeric value**.
-:::
-
-## 3. MAX
-Get the maximum value of a defined property for incoming events. During a billable period, Lago will get the maximum value received for a defined property. At the end of the billable period, this value resumes to 0.
-
-This aggregation is very useful to get the maximum usage of a feature, such as *the maximum number of rows* or *the maximum compute time of a server*, for instance.
-
-`MAX(event.properties.property_name)`
-
-:::caution
-As a `MAX` returns a number, the single property you aggregate on **must be numeric value**.
-:::
-
-
-## 4. COUNT DISTINCT
-Get the number of unique value of a defined property for incoming events. During a billable period, Lago will deduplicate the number of events received over a single property. At the end of the billable period, this value resumes to 0.
-
-This aggregation is very useful to deduplicate, such as the *number of tracked users* or *the number of active rows*, for instance.
-
-`COUNT_DISTINCT(event.properties.property_name)`


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

Document the event and batch event changes to add or remove a recurring persisted object.