### PR TITLE
feat(error): Document not allowed error

### DIFF
--- a/docs/api/02_billable_metrics/destroy-billable-metric.mdx
+++ b/docs/api/02_billable_metrics/destroy-billable-metric.mdx
@@ -73,7 +73,7 @@ import TabItem from '@theme/TabItem';
         // Error is *lago.Error
         panic(err)
       }
-        
+
       // billableMetric is *lago.BillableMetric
       fmt.Println(billableMetric)
     }
@@ -122,13 +122,13 @@ import TabItem from '@theme/TabItem';
   The `billable_metric` was not found by the code.
   </TabItem>
 
-  <TabItem value="403" label="HTTP 403">
+  <TabItem value="405" label="HTTP 405">
 
   ```json
   {
-    "status": 403,
-    "error": "Forbidden",
-    "message": "Billable metric is attached to an active subscriptions."
+    "status": 405,
+    "error": "Method Not Allowed",
+    "code": "attached_to_an_active_subscription"
   }
   ```
 

--- a/docs/api/03_plans/destroy-plan.mdx
+++ b/docs/api/03_plans/destroy-plan.mdx
@@ -73,7 +73,7 @@ import TabItem from '@theme/TabItem';
         // Error is *lago.Error
         panic(err)
       }
-        
+
       // plan is *lago.Plan
       fmt.Println(plan)
     }
@@ -122,13 +122,13 @@ import TabItem from '@theme/TabItem';
   The `plan` was not found by the code.
   </TabItem>
 
-  <TabItem value="403" label="HTTP 403">
+  <TabItem value="405" label="HTTP 405">
 
   ```json
   {
-    "status": 403,
-    "error": "Forbidden",
-    "message": "Plan is attached to active subscriptions."
+    "status": 405,
+    "error": "Method Not Allowed",
+    "code": "attached_to_an_active_subscription"
   }
   ```
 

--- a/docs/api/07_coupons/destroy-coupon.mdx
+++ b/docs/api/07_coupons/destroy-coupon.mdx
@@ -73,7 +73,7 @@ import TabItem from '@theme/TabItem';
         // Error is *lago.Error
         panic(err)
       }
-        
+
       // coupon is *lago.Coupon
       fmt.Println(coupon)
     }
@@ -122,13 +122,13 @@ import TabItem from '@theme/TabItem';
   The `coupon` was not found by the code.
   </TabItem>
 
-  <TabItem value="403" label="HTTP 403">
+  <TabItem value="405" label="HTTP 405">
 
   ```json
   {
-    "status": 403,
-    "error": "Forbidden",
-    "message": "Coupon is attached to an active customer."
+    "status": 405,
+    "error": "Method Not Allowed",
+    "code": "attached_to_an_active_customer"
   }
   ```
 


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API needs a complete refactoring.

## Description

The objective of this pull request is to document all the `405 Method Not Allowed` HTTP errors returned in the API end points

## See also

Related to https://github.com/getlago/lago-api/pull/444