### PR TITLE
feat: Add previous and next external id to subscription object

### DIFF
--- a/docs/api/05_subscriptions/subscription-object.mdx
+++ b/docs/api/05_subscriptions/subscription-object.mdx
@@ -29,7 +29,9 @@ The subscription will then define how a the related customer will be invoiced ba
     "subscription_date": "2022-04-29",
     "terminated_at": null,
     "previous_plan_code": null,
-    "next_plan_code": null
+    "next_plan_code": null,
+    "previous_external_id": null,
+    "next_external_id": null
   }
 }
 ```
@@ -51,6 +53,8 @@ The subscription will then define how a the related customer will be invoiced ba
 | **terminated_at** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Termination date of the subscription. It's not null when the subscription is `terminated` |
 | **previous_plan_code** &nbsp &nbsp <Type>String</Type> | Code identifying the previous plan. |
 | **next_plan_code** &nbsp &nbsp <Type>String</Type> | Code identifying the next plan, in case of downgrade. |
+| **previous_external_id** &nbsp &nbsp <Type>String</Type> | Unique external identifier of the previous subscription. |
+| **next_external_id** &nbsp &nbsp <Type>String</Type> | Unique external identifier of the next subscription, in case of downgrade. |
 
 export const Type = ({children, color}) => (
   <span


### PR DESCRIPTION
We want to add the `previous_external_id` and `next_external_id` to the subscription object.