### PR TITLE
feat(errors): Document former missing arguments errors

### DIFF
--- a/docs/api/05_subscriptions/create-subscription.mdx
+++ b/docs/api/05_subscriptions/create-subscription.mdx
@@ -194,20 +194,44 @@ If the customer is not found, it will be created with blank metadata
 
   </TabItem>
 
+  <TabItem value="404" label="HTTP 404">
+
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "code": "customer_not_found"
+  }
+  ```
+
+  **Possible error codes:**
+  * `customer_not_found`: The external customer id does not match an existing customer.
+  * `plan_not_found`: The plan code does not match an existing plan.
+
+
+  </TabItem>
+
   <TabItem value="422" label="HTTP 422">
 
   ```json
   {
     "status": 422,
     "error": "Unprocessable entity",
-    "message": "message"
+    "code": "validation_errors",
+    "error_details": {
+      "field": ["error"]
     }
   }
   ```
 
-  **Possible error messages:**
-  * `plan does not exists`: The plan code does not match an exisiting plan.
+  **Possible errors:**
 
+  | Field | Code | Description |
+  |--|--|--|
+  | `billing_time` | `value_is_invalid` | Provided `billing_time` does not match an accepted value |
+  | `currency` | `currencies_does_not_match` | The plan currency differs from the customer currency |
+  | `external_id` | `value_already_exists` | The external id is already assigned to an active subscription |
+  | `external_id` | `value_is_mandatory` | No external id was provided in the request payload |
 
   </TabItem>
 </Tabs>

--- a/docs/api/07_coupons/apply-coupon.mdx
+++ b/docs/api/07_coupons/apply-coupon.mdx
@@ -177,6 +177,23 @@ import TabItem from '@theme/TabItem';
 
   </TabItem>
 
+  <TabItem value="404" label="HTTP 404">
+
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "code": "customer_not_found"
+  }
+  ```
+
+  **Possible error codes:**
+  * `customer_not_found`: The external customer id does not match an existing customer.
+  * `coupon_not_found`: The coupon code does not match an existing coupon.
+
+
+  </TabItem>
+
   <TabItem value="422" label="HTTP 422">
 
   ```json
@@ -188,8 +205,6 @@ import TabItem from '@theme/TabItem';
   ```
 
   **Possible error messages:**
-  * `unable_to_find_customer`: The customer id does not match an existing customer.
-  * `coupon_does_not_exist`: The coupon code does not match an existing coupon.
   * `no_active_subscription`: The customer does not have an active subscription.
   * `coupon_already_applied`: A coupon is already applied to the customer.
   * `currencies_does_not_match`: Provided currency does not match the currency of the customer's plan.

--- a/docs/api/08_add_ons/apply-add-on.mdx
+++ b/docs/api/08_add_ons/apply-add-on.mdx
@@ -179,6 +179,23 @@ import TabItem from '@theme/TabItem';
 
   </TabItem>
 
+  <TabItem value="404" label="HTTP 404">
+
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "code": "customer_not_found"
+  }
+  ```
+
+  **Possible error codes:**
+  * `customer_not_found`: The external customer id does not match an existing customer.
+  * `add_on_not_found`: The add-on code does not match an existing add-on.
+
+
+  </TabItem>
+
   <TabItem value="422" label="HTTP 422">
 
   ```json
@@ -190,8 +207,6 @@ import TabItem from '@theme/TabItem';
   ```
 
   **Possible error messages:**
-  * `unable_to_find_customer`: The customer id does not match an existing customer.
-  * `add_on_does_not_exist`: The add-on code does not match an existing add-on.
   * `no_active_subscription`: The customer does not have an active subscription.
   * `currencies_does_not_match`: Provided currency does not match the currency of the customer's plan.
   * `Validation error on the record`: The `error_details` field contains the details of the errors:
@@ -296,6 +311,3 @@ export const NotNullable = ({children, color}) => (
     {children}
   </span>
 );
-
-
-

--- a/docs/api/11_webhooks/messages.mdx
+++ b/docs/api/11_webhooks/messages.mdx
@@ -272,6 +272,22 @@ This webhook is sent when there is an error related to the creation of an event.
   }
 }
 ```
+
+| Attributes | Description |
+| -----------| ----------- |
+| **status** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | HTTP status of the error. Possible statuses are `404` or `422` |
+| **error** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | HTTP error code. Possible errors are `Not found` or `Unprocessable entity` |
+| **message** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Error code. See next list for the description of each error code. |
+| **input_params** &nbsp &nbsp <Type>JSON</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | JSON provided at event creation |
+
+| Code | Description |
+|--|--|
+| **billable_metric_not_found** &nbsp &nbsp <Type>404</Type> | No billable metric matches the given code |
+| **customer_not_found** &nbsp &nbsp <Type>404</Type> | No customer matches the external id |
+| **subscription_not_found** &nbsp &nbsp <Type>404</Type> | No subscription matches the given external subscription id |
+| **invalid_argument** &nbsp &nbsp <Type>422</Type> | No subscription matches the given external subscription id |
+| **invalid_recurring_resource** &nbsp &nbsp <Type>422</Type> | Provided recurring resource for persisted event is invalid |
+
 </TabItem>
 
 <TabItem value="payment_provider_created" label="Payment provider created">


### PR DESCRIPTION
# Description

This PR documents error status for former `missing_argument` errors (previously returned as 422) that were turned into proper `404` errors:

This impacts:
- Apply a coupon route
- Apply an add on route
- Create a subscription route
- Event error webhook

# Related to

https://github.com/getlago/lago-api/pull/462