### PR TITLE
feat(errors): Document error handling on invoice status update

### DIFF
--- a/docs/api/09_invoices/update-invoice-status.mdx
+++ b/docs/api/09_invoices/update-invoice-status.mdx
@@ -182,12 +182,19 @@ import TabItem from '@theme/TabItem';
   {
     "status": 422,
     "error": "Unprocessable entity",
-    "message": "message"
+    "code": "validation_errors",
+    "error_details": {
+      "field": ["error"]
+    }
   }
   ```
 
-  **Possible error messages:**
+  **Possible errors:**
   * `invalid_status`: The status in the request does not exist or is invalid.
+
+  | Field | Code | Description |
+  |--|--|--|
+  | `status` | `value_is_invalid` | Provided `status` does not match an accepted value |
 
 
   </TabItem>

--- a/docs/api/09_invoices/update-invoice-status.mdx
+++ b/docs/api/09_invoices/update-invoice-status.mdx
@@ -190,7 +190,6 @@ import TabItem from '@theme/TabItem';
   ```
 
   **Possible errors:**
-  * `invalid_status`: The status in the request does not exist or is invalid.
 
   | Field | Code | Description |
   |--|--|--|


### PR DESCRIPTION
# Description

This PR documents the validation error of the `PUT /api/v1/invoices/:id` route

# Related to

https://github.com/getlago/lago-api/pull/477