### PR TITLE
feat(customers): Document customer currency

### DIFF
--- a/docs/api/04_customers/create-update-customer.mdx
+++ b/docs/api/04_customers/create-update-customer.mdx
@@ -32,6 +32,7 @@ import TabItem from '@theme/TabItem';
         "address_line2": null,
         "city": "Woodland Hills",
         "country": "US",
+        "currency": "EUR",
         "email": "dinesh@piedpiper.test",
         "legal_name": "Coleman-Blair",
         "legal_number": "49-008-2965",
@@ -66,6 +67,7 @@ import TabItem from '@theme/TabItem';
     address_line1="5230 Penfield Ave",
     address_line2=None,
     city="Woodland Hills",
+    currency="EUR",
     country="US",
     email="test@example.com",
     legal_name="Coleman-Blair",
@@ -104,6 +106,7 @@ import TabItem from '@theme/TabItem';
     None,  // addressLine2
     None,  // city
     None,  // country
+    "EUR", // currency
     "test@example.com",  // email
     None,  // legalName
     None,  // legalNumber
@@ -137,6 +140,7 @@ import TabItem from '@theme/TabItem';
     address_line2: nil,
     city: "Woodland Hills",
     country: "US",
+    currency: "EUR",
     email: "dinesh@piedpiper.test",
     legal_name: "Coleman-Blair",
     legal_number: "49-008-2965",
@@ -175,6 +179,7 @@ import TabItem from '@theme/TabItem';
         AddressLine2: "Address Line 2",
         City:         "Paris",
         Country:      "France",
+        Currency:     "EUR",
         State:        "Paris",
         Zipcode:      "75001",
         LegalName:    "GetLago",
@@ -219,6 +224,7 @@ import TabItem from '@theme/TabItem';
     "address_line2": null,
     "city": "Woodland Hills",
     "country": "US",
+    "currency": "EUR",
     "email": "dinesh@piedpiper.test",
     "legal_name": "Coleman-Blair",
     "legal_number": "49-008-2965",
@@ -248,6 +254,7 @@ If the customer already exists, the call will work as an update
 | address_line2 | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Second line of the billing address |
 | city | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | City of the customer's billing address |
 | country | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional><br></br><Comment>*ISO 3166 alpha 2 Country code.*</Comment>| Country code of the customer's billing address |
+| currency | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Currency of customer |
 | email | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Email of the customer |
 | legal_name | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Legal company name of the customer |
 | legal_number | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Legal company number of the customer |
@@ -315,20 +322,21 @@ If the customer already exists, the call will work as an update
   {
     "status": 422,
     "error": "Unprocessable entity",
-    "message": "message",
+    "code": "validation_errors",
     "error_details": {
       "field": ["message"]
     }
   }
   ```
 
-  Possible error messages:
-  - `Validation error on the record`: The `error_details` field contains the details of the errors
+  **Possible errors:**
 
   | field | error | description |
   |--|--|--|
   | `external_id` | `value_is_mandatory` | external_id is missing |
   | `country` | `not_a_valid_country_code` | Provided country value is not an ISO 3166 country code |
+  | `currency` | `value_is_invalid` | Provided currency is not an accepted currency |
+  | `currency` | `currencies_does_not_match` | Provided currency cannot be assigned to the customer as he already has a subscription, an add_on, a coupon or a wallet in an other currency. |
   | `vat_rate` | `value_is_out_of_range` | Provided VAT rate is invalid.<br/>It must be a positive integer or floating number between 0 and 100. |
 
 

--- a/docs/api/04_customers/customer-object.mdx
+++ b/docs/api/04_customers/customer-object.mdx
@@ -34,6 +34,7 @@ It lets you create a customer, but also track usage and create invoices for the 
     "url": "http://hooli.com",
     "vat_rate": 12.5,
     "zipcode": "91364",
+    "currency": "EUR",
     "billing_configuration": {
       "payment_provider": "stripe",
       "provider_customer_id": "cus_12345"
@@ -53,6 +54,7 @@ It lets you create a customer, but also track usage and create invoices for the 
 | **address_line2** &nbsp &nbsp <Type>String</Type> | Second line of the billing address |
 | **city** &nbsp &nbsp <Type>String</Type> | City of the customer's billing address |
 | **country** &nbsp &nbsp <Type>String</Type><br></br><Comment>*ISO 3166 alpha 2 Country code.*</Comment> | Country code of the customer's billing address |
+| **currency** &nbsp &nbsp <Type>String</Type> | Currency of the customer |
 | **email** &nbsp &nbsp <Type>String</Type> | Email of the customer |
 | **legal_name** &nbsp &nbsp <Type>String</Type> | Legal company name of the customer |
 | **legal_number** &nbsp &nbsp <Type>String</Type> | Legal company number of the customer |


### PR DESCRIPTION
# Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

# Description

The role of this PR is to document the new currency field of the customer object and how to assign and update it as well as the validation rules that apply to it.