### PR TITLE
misc: Use graduated ranges and volume ranges as hash

### DIFF
--- a/docs/api/03_plans/create-plan.mdx
+++ b/docs/api/03_plans/create-plan.mdx
@@ -85,7 +85,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
           "billable_metric_id": "__BILLABLE_METRIC_ID__",
           "charge_model": "volume",
           "properties": {
-            "ranges": [
+            "volume_ranges": [
               {
                 "to_value": 10,
                 "from_value": 0,
@@ -167,7 +167,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
     billable_metric_id='id,
     charge_model='volume',
     properties={
-      'ranges': [
+      'volume_ranges': [
         {
           'to_value': 10,
           'from_value': 0,
@@ -270,7 +270,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         billable_metric_id: 'id',
         charge_model: 'volume',
         properties: {
-          ranges: [
+          volume_ranges: [
             {
               to_value: 10,
               from_value: 0,
@@ -353,7 +353,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
     billableMetricId: 'id',
     chargeModel: 'volume',
     properties: {
-      ranges: [
+      volume_ranges: [
         {
           to_value: 10,
           from_value: 0,
@@ -491,7 +491,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "charge_model": "volume",
         "properties": {
-          "ranges": [
+          "volume_ranges": [
             {
               "to_value": 10,
               "from_value": 0,
@@ -542,9 +542,9 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
 
 | Attributes | Type | Description |
 |--|--|--|
-| - | Array<br></br><Required>**Required**</Required> | Graduated ranges, sorted from bottom to top boundaries |
+| graduated_ranges | Array<br></br><Required>**Required**</Required> | Graduated ranges, sorted from bottom to top boundaries |
 
-- Ranges:
+- Graduated Ranges:
 
 | Attributes | Type | Description |
 |--|--|--|
@@ -574,9 +574,9 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
 
 | Attributes | Type | Description |
 |--|--|--|
-| ranges | Array<br></br><Required>**Required**</Required> | Volume ranges, sorted from bottom to top boundaries |
+| volume_ranges | Array<br></br><Required>**Required**</Required> | Volume ranges, sorted from bottom to top boundaries |
 
-- Ranges:
+- Volume Ranges:
 
 | Attributes | Type | Description |
 |--|--|--|
@@ -673,7 +673,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
 
   | Field | Code | Description |
   |--|--|--|
-  | `properties` | `missing_graduated_range` | Range values are missing |
+  | `properties` | `missing_graduated_ranges` | Range values are missing |
   | `properties` | `invalid_graduated_ranges` | One of the range attributes is invalid |
   | `properties` | `invalid_amount` | The value provided for `per_unit_amount` or `flat_amount` is invalid |
 
@@ -698,8 +698,8 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
 
   | Field | Code | Description |
   |--|--|--|
-  | `properties` | `missing_ranges` | Range values are missing |
-  | `properties` | `invalid_ranges` | One of the range attributes is invalid |
+  | `properties` | `missing_volume_ranges` | Range values are missing |
+  | `properties` | `invalid_volume_ranges` | One of the range attributes is invalid |
   | `properties` | `invalid_amount` | Value provided for `per_unit_amount` or `flat_amount` is invalid |
 
 

--- a/docs/api/03_plans/plan-object.mdx
+++ b/docs/api/03_plans/plan-object.mdx
@@ -81,7 +81,7 @@ This object represents a plan.<br></br>
         "created_at": "2022-08-24T14:58:59Z",
         "charge_model": "volume",
         "properties": {
-          "ranges": [
+          "volume_ranges": [
             {
               "to_value": 10,
               "from_value": 0,
@@ -137,9 +137,9 @@ This object represents a plan.<br></br>
 
 | Attributes | Description |
 | -----------| ----------- |
-| **Array of ranges** | Graduated ranges, sorted from bottom to top boundaries |
+| **graduated_ranges** &nbsp &nbsp <Type>Array of ranges</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Graduated ranges, sorted from bottom to top boundaries |
 
-- Ranges:
+- Graduated Ranges:
 
 | Attributes | Description |
 | -----------| ----------- |
@@ -169,9 +169,9 @@ This object represents a plan.<br></br>
 
 | Attributes | Description |
 | -----------| ----------- |
-| **ranges** &nbsp &nbsp <Type>Array of ranges</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Volume ranges, sorted from bottom to top boundaries |
+| **volume_ranges** &nbsp &nbsp <Type>Array of ranges</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Volume ranges, sorted from bottom to top boundaries |
 
-- Ranges:
+- Volume Ranges:
 
 | Attributes | Description |
 | -----------| ----------- |

--- a/docs/api/03_plans/update-plan.mdx
+++ b/docs/api/03_plans/update-plan.mdx
@@ -90,7 +90,7 @@ curl --location --request PUT "$LAGO_URL/api/v1/plans/__plan_code__" \
           "billable_metric_id": "__BILLABLE_METRIC_ID__",
           "charge_model": "volume",
           "properties": {
-            "ranges": [
+            "volume_ranges": [
               {
                 "to_value": 10,
                 "from_value": 0,
@@ -177,7 +177,7 @@ standard_charge = Charge(
     billable_metric_id='id,
     charge_model='volume',
     properties={
-      'ranges': [
+      'volume_ranges': [
         {
           'to_value': 10,
           'from_value': 0,
@@ -285,7 +285,7 @@ standard_charge = Charge(
         billable_metric_id: 'id',
         charge_model: 'volume',
         properties: {
-          ranges: [
+          volume_ranges: [
             {
               to_value: 10,
               from_value: 0,
@@ -374,7 +374,7 @@ standard_charge = Charge(
     billableMetricId: 'id',
     chargeModel: 'volume',
     properties: {
-      ranges: [
+      volume_ranges: [
         {
           to_value: 10,
           from_value: 0,
@@ -516,7 +516,7 @@ standard_charge = Charge(
         "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "charge_model": "volume",
         "properties": {
-          "ranges": [
+          "volume_ranges": [
             {
               "to_value": 10,
               "from_value": 0,
@@ -569,9 +569,9 @@ Charges cannot be updated if the plan is linked to a subscription
 
 | Attributes | Type | Description |
 |--|--|--|
-| - | Array<br></br><Required>**Required**</Required> | Graduated ranges, sorted from bottom to top boundaries |
+| graduated_ranges | Array<br></br><Required>**Required**</Required> | Graduated ranges, sorted from bottom to top boundaries |
 
-- Ranges:
+- Graduated Ranges:
 
 | Attributes | Type | Description |
 |--|--|--|
@@ -601,9 +601,9 @@ Charges cannot be updated if the plan is linked to a subscription
 
 | Attributes | Type | Description |
 |--|--|--|
-| ranges | Array<br></br><Required>**Required**</Required> | Volume ranges, sorted from bottom to top boundaries |
+| volume_ranges | Array<br></br><Required>**Required**</Required> | Volume ranges, sorted from bottom to top boundaries |
 
-- Ranges:
+- Volume Ranges:
 
 | Attributes | Type | Description |
 |--|--|--|
@@ -704,7 +704,7 @@ Charges cannot be updated if the plan is linked to a subscription
 
   | Field | Code | Description |
   |--|--|--|
-  | `properties` | `missing_graduated_range` | Range values are missing |
+  | `properties` | `missing_graduated_ranges` | Range values are missing |
   | `properties` | `invalid_graduated_ranges` | One of the range attributes is invalid |
   | `properties` | `invalid_amount` | Value provided for `per_unit_amount` or `flat_amount` is invalid |
 
@@ -729,8 +729,8 @@ Charges cannot be updated if the plan is linked to a subscription
 
   | Field | Code | Description |
   |--|--|--|
-  | `properties` | `missing_ranges` | Range values are missing |
-  | `properties` | `invalid_ranges` | One of the range attributes is invalid |
+  | `properties` | `missing_volume_ranges` | Range values are missing |
+  | `properties` | `invalid_volume_ranges` | One of the range attributes is invalid |
   | `properties` | `invalid_amount` | Value provided for `per_unit_amount` or `flat_amount` is invalid |
 
 


### PR DESCRIPTION
## Context

In order to be consistent between all charge models, we want to store `properties` by using the same type.

## Description

The goal of this MR is to:
- update `properties` from `array` to `hash` for graduated charges
- rename `ranges` to `volume_ranges` for the volume properties key