### PR TITLE
misc: Move fields related to Billing or Invoice into billing_configuration

### DIFF
--- a/docs/api/04_customers/create-update-customer.mdx
+++ b/docs/api/04_customers/create-update-customer.mdx
@@ -58,7 +58,7 @@ import TabItem from '@theme/TabItem';
 
   ```python
   from lago_python_client import Client
-  from lago_python_client.models import Customer, BillingConfiguration
+  from lago_python_client.models import Customer, CustomerBillingConfiguration
 
   client = Client(api_key='__YOUR_API_KEY__')
 
@@ -78,7 +78,7 @@ import TabItem from '@theme/TabItem';
     state="CA",
     url="http://hooli.com",
     zipcode="91364",
-    billing_configuration=BillingConfiguration(
+    billing_configuration=CustomerBillingConfiguration(
       payment_provider="stripe",
       provider_customer_id="cus_12345",
       sync=true,
@@ -96,7 +96,7 @@ import TabItem from '@theme/TabItem';
   ```javascript
   import Client from 'lago-nodejs-client'
   import Customer from 'lago-nodejs-client/customer'
-  import BillingConfiguration from 'lago-nodejs-client/billing_configuration'
+  import CustomerBillingConfiguration from 'lago-nodejs-client/customer_billing_configuration'
 
   let client = new Client('__API_KEY__')
 
@@ -116,7 +116,7 @@ import TabItem from '@theme/TabItem';
     None,  // state
     None,  // url
     None,  // zipcode
-    new BillingConfiguration(
+    new CustomerBillingConfiguration(
       "stripe",  // paymentProvider
       "cus_12345",  // providerCustomerId
       true,  // sync
@@ -186,7 +186,7 @@ import TabItem from '@theme/TabItem';
         LegalNumber:  "123456",
         Phone:        "+330100000000",
         URL:          "https://getlago.com",
-        BillingConfiguration: &BillingConfigurationInput{
+        BillingConfiguration: &CustomerBillingConfigurationInput{
           PaymentProvider: lago.PaymentProviderStripe,
           ProviderCustomerID: "__STRIPE_CUSTOMER_ID__",
           VatRate: 20.0,

--- a/docs/api/04_customers/create-update-customer.mdx
+++ b/docs/api/04_customers/create-update-customer.mdx
@@ -41,12 +41,12 @@ import TabItem from '@theme/TabItem';
         "phone": "1-171-883-3711 x245",
         "state": "CA",
         "url": "http://hooli.com",
-        "vat_rate": 12.5,
         "zipcode": "91364",
         "billing_configuration": {
           "payment_provider": "stripe",
           "provider_customer_id": "cus_12345",
-          "sync": true
+          "sync": true,
+          "vat_rate": 12.5
         }
       }
     }'
@@ -77,12 +77,12 @@ import TabItem from '@theme/TabItem';
     phone="1-171-883-3711 x245",
     state="CA",
     url="http://hooli.com",
-    vat_rate=12.5,
     zipcode="91364",
     billing_configuration=BillingConfiguration(
       payment_provider="stripe",
       provider_customer_id="cus_12345",
-      sync=true
+      sync=true,
+      vat_rate=12.5
     )
   )
 
@@ -115,12 +115,12 @@ import TabItem from '@theme/TabItem';
     None,  // phone
     None,  // state
     None,  // url
-    None,  // vatRate
     None,  // zipcode
     new BillingConfiguration(
-      "stripe",
-      "cus_12345",
-      true
+      "stripe",  // paymentProvider
+      "cus_12345",  // providerCustomerId
+      true,  // sync
+      None  // vatRate
     )
   )
   await client.createCustomer(customer);
@@ -149,12 +149,12 @@ import TabItem from '@theme/TabItem';
     phone: "1-171-883-3711 x245",
     state: "CA",
     url: "http://hooli.com",
-    vat_rate: 12.5,
     zipcode: "91364",
     billing_configuration: {
       payment_provider: "stripe",
       provider_customer_id: "cus_12345",
-      sync: true
+      sync: true,
+      vat_rate: 12.5
     }
   )
   ```
@@ -186,10 +186,10 @@ import TabItem from '@theme/TabItem';
         LegalNumber:  "123456",
         Phone:        "+330100000000",
         URL:          "https://getlago.com",
-        VatRate:      20.0,
         BillingConfiguration: &BillingConfigurationInput{
           PaymentProvider: lago.PaymentProviderStripe,
           ProviderCustomerID: "__STRIPE_CUSTOMER_ID__",
+          VatRate: 20.0,
         }
       }
 
@@ -233,12 +233,12 @@ import TabItem from '@theme/TabItem';
     "phone": "1-171-883-3711 x245",
     "state": "CA",
     "url": "http://hooli.com",
-    "vat_rate": 12.5,
     "zipcode": "91364",
     "billing_configuration": {
       "payment_provider": "stripe",
       "provider_customer_id": "cus_12345",
-      "sync": true
+      "sync": true,
+      "vat_rate": 12.5
     }
   }
 }
@@ -263,7 +263,6 @@ If the customer already exists, the call will work as an update
 | phone | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Phone number of the customer |
 | state | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | State of the customer's billing address |
 | url | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Custom URL of the customer |
-| vat_rate | Float &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Custom VAT applied to the customer.<br></br> It will override the one defined at organization level |
 | zipcode | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Zipcode of the customer's billing address |
 | billing_configuration | Object &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Payment provider specific configuration used to bill the customer |
 
@@ -274,6 +273,7 @@ If the customer already exists, the call will work as an update
 | payment_provider | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Payment provider used to bill the customer.<br/>Only accepted value: `stripe`, this field is required if you want to assign a `provider_customer_id`
 | provider_customer_id | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Customer ID on the payment provider.<br/>If not provided, Lago can optionally create the provider customer
 | sync | Boolean &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Set to true is you want to create the provider customer synchronously with the customer creation.<br/>Apply only when provider_customer_id is null and payment provider is configured to create customer.<br/>Default value: `false`
+| vat_rate | Float &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Custom VAT applied to the customer.<br></br> It will override the one defined at organization level |
 
 ## Responses
 

--- a/docs/api/04_customers/customer-object.mdx
+++ b/docs/api/04_customers/customer-object.mdx
@@ -63,7 +63,6 @@ It lets you create a customer, but also track usage and create invoices for the 
 | **phone** &nbsp &nbsp <Type>String</Type> | Phone number of the customer |
 | **state** &nbsp &nbsp <Type>String</Type> | State of the customer's billing address |
 | **url** &nbsp &nbsp <Type>String</Type> | Custom URL of the customer |
-| **vat_rate** &nbsp &nbsp <Type>Float</Type> | Custom VAT rate applied to the customer |
 | **zipcode** &nbsp &nbsp <Type>String</Type> | Zipcode of the customer's billing address |
 
 ## Billing Configuration Object
@@ -71,7 +70,8 @@ It lets you create a customer, but also track usage and create invoices for the 
 | Attributes | Description |
 | -----------| ----------- |
 | payment_provider &nbsp &nbsp <Type>String</Type> | Payment provider used to bill the customer. <details><summary>**Possible values**</summary><div>- `stripe`: Use stripe as a payment provider.<br></br>- null: No payment providers. Only webhooks will be send to process customer billing.<div></div></div></details> |
-| provider_customer_id  &nbsp &nbsp <Type>String</Type> | Customer ID on the payment provider. |
+| provider_customer_id &nbsp &nbsp <Type>String</Type> | Customer ID on the payment provider. |
+| vat_rate &nbsp &nbsp <Type>Float</Type> | Custom VAT rate applied to the customer. |
 
 export const Type = ({children, color}) => (
   <span

--- a/docs/api/10_organizations/organization-object.mdx
+++ b/docs/api/10_organizations/organization-object.mdx
@@ -14,7 +14,6 @@ This object represents an organization.<br></br>
     "name": "Name1",
     "created_at": "2022-05-02T13:04:09Z",
     "webhook_url": "https://test-example.example",
-    "vat_rate": 15.0,
     "country": "CZ",
     "address_line1": "address1",
     "address_line2": null,
@@ -24,7 +23,10 @@ This object represents an organization.<br></br>
     "city": "city125",
     "legal_name": null,
     "legal_number": null,
-    "invoice_footer": "footer custom"
+    "billing_configuration": {
+      "invoice_footer": "footer custom",
+      "vat_rate": 15.0
+    }
   }
 }
 ```
@@ -34,7 +36,6 @@ This object represents an organization.<br></br>
 | **name** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Organization name. |
 | **created_at** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> &nbsp &nbsp <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date of organization creation. |
 | **webhook_url** &nbsp &nbsp <Type>String</Type> | Webhook URL. |
-| **vat_rate** &nbsp &nbsp <Type>Float</Type> | VAT rate used in fees. |
 | **country** &nbsp &nbsp <Type>String</Type> | Valid country alpha-2 code. |
 | **address_line1** &nbsp &nbsp <Type>String</Type> | Address first line. |
 | **address_line2** &nbsp &nbsp <Type>String</Type> | Address second line. |
@@ -44,8 +45,13 @@ This object represents an organization.<br></br>
 | **city** &nbsp &nbsp <Type>String</Type> | Organization city. |
 | **legal_name** &nbsp &nbsp <Type>String</Type> | Organization legal name. |
 | **legal_number** &nbsp &nbsp <Type>String</Type> | Organization legal number. |
-| **invoice_footer** &nbsp &nbsp <Type>String</Type> | Custom footer used in invoices. |
 
+## Billing Configuration Object
+
+| Attributes | Description |
+| -----------| ----------- |
+| invoice_footer &nbsp &nbsp <Type>String</Type> | Custom footer used in invoices. |
+| vat_rate &nbsp &nbsp <Type>Float</Type> | VAT rate used in fees. |
 
 export const Type = ({children, color}) => (
   <span

--- a/docs/api/10_organizations/update-organization.mdx
+++ b/docs/api/10_organizations/update-organization.mdx
@@ -29,7 +29,6 @@ import TabItem from '@theme/TabItem';
       "organization": {
         "name": "Name1",
         "webhook_url": "https://test-example.example",
-        "vat_rate": 15.0,
         "country": "CZ",
         "address_line1": "address1",
         "address_line2": null,
@@ -39,7 +38,10 @@ import TabItem from '@theme/TabItem';
         "city": "city125",
         "legal_name": null,
         "legal_number": null,
-        "invoice_footer": "footer custom"
+        "billing_configuration": {
+          "invoice_footer": "footer custom",
+          "vat_rate": 15.0
+        }
       }
     }'
   ```
@@ -49,13 +51,17 @@ import TabItem from '@theme/TabItem';
 
   ```python
   from lago_python_client import Client
-  from lago_python_client.models import Organization
+  from lago_python_client.models import Organization, OrganizationBillingConfiguration
 
   client = Client(api_key='__YOUR_API_KEY__')
 
   params = Organization(
     webhook_url="https://new.url",
-    vat_rate=14.2
+    vat_rate=14.2,
+    billing_configuration=OrganizationBillingConfiguration(
+      invoice_footer="footer custom",
+      vat_rate=12.5
+    )
   )
   client.organizations().update(params)
   ```
@@ -70,7 +76,10 @@ import TabItem from '@theme/TabItem';
 
   update_params = {
     webhook_url: 'https://webhook_url.com',
-    vat_rate: 10
+    billing_configuration: {
+      invoice_footer="footer custom",
+      vat_rate: 10
+    }
   }
   client.organizations.update(update_params)
   ```
@@ -80,12 +89,16 @@ import TabItem from '@theme/TabItem';
 
   ```javascript
   import Organization from 'lago-nodejs-client/organization'
+  import OrganizationBillingConfiguration from 'lago-nodejs-client/organization_billing_configuration'
 
   let client = new Client('__API_KEY__')
 
   await client.updateOrganization(new Organization({
     webhookUrl: "https://newwebhookurl.com",
-    vatRate: 15.5
+    billingConfiguration: new OrganizationBillingConfiguration({
+      invoiceFooter: "footer custom",
+      vatRate: 15.5
+    })
   }))
   ```
   </TabItem>
@@ -102,6 +115,10 @@ import TabItem from '@theme/TabItem';
 
       organizationInput := &lago.OrganizationInput{
         LegalName: "Legal Name",
+        BillingConfiguration: &OrganizationBillingConfigurationInput{
+          InvoiceFooter: "footer custom",
+          VatRate: 20.0,
+        }
       }
 
       organization, err := lagoClient.Organization().Update(organizationInput)
@@ -124,7 +141,6 @@ import TabItem from '@theme/TabItem';
 {
   "organization": {
     "webhook_url": "https://test-example.example",
-    "vat_rate": 15.0,
     "country": "CZ",
     "address_line1": "address1",
     "address_line2": null,
@@ -134,7 +150,10 @@ import TabItem from '@theme/TabItem';
     "city": "city125",
     "legal_name": null,
     "legal_number": null,
-    "invoice_footer": "footer custom"
+    "billing_configuration": {
+      "invoice_footer": "footer custom",
+      "vat_rate": 15.0
+    }
   }
 }
 ```
@@ -142,7 +161,6 @@ import TabItem from '@theme/TabItem';
 | Attributes | Type | Description |
 |--|--|--|
 | webhook_url | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Webhook URL. |
-| vat_rate | Float &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | VAT rate. |
 | country | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Country alpha-2 code |
 | address_line1 | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Address first line. |
 | address_line2 | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Address second line. |
@@ -152,7 +170,15 @@ import TabItem from '@theme/TabItem';
 | city | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Organization city. |
 | legal_name | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Organization legal name. |
 | legal_number | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Organization legal number. |
+| billing_configuration | Object &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Invoicing an billing specific configuration. |
+
+### Billing configuration
+
+| Attributes | Type | Description |
+| -----------| -----| ----------- |
 | invoice_footer | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Custom invoice footer. |
+| vat_rate | Float &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Custom VAT rate. |
+
 ## Responses
 
 <Tabs>


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Description

The goal of this PR is to move fields related to Billing or Invoice into `billing_configuration`.

For customer: `vat_rate`.

For organization: `invoice_footer`, `vat_rate`.
