### PR TITLE
FIX: Create wallet documentation missing currency argument - create-wallet.mdx

### DIFF
--- a/docs/api/13_wallets/create-wallet.mdx
+++ b/docs/api/13_wallets/create-wallet.mdx
@@ -31,6 +31,7 @@ import TabItem from '@theme/TabItem';
         "rate_amount": "1.5",
         "paid_credits": "20.0",
         "granted_credits": "10.0",
+        "currency": "USD",
         "expiration_date": "2022-07-07",
         "external_customer_id": "12345"
       }
@@ -51,6 +52,7 @@ import TabItem from '@theme/TabItem';
     rate_amount='1.5',
     paid_credits='20.0',
     granted_credits='10.0',
+    currency='USD',
     expiration_date='2022-07-07',
     external_customer_id='12345'
   )
@@ -70,6 +72,7 @@ import TabItem from '@theme/TabItem';
       rate_amount: '1.5',
       paid_credits: '20.0',
       granted_credits: '10.0',
+      currency:'USD',
       expiration_date: '2022-07-07',
       external_customer_id: '12345'
   })
@@ -105,6 +108,7 @@ import TabItem from '@theme/TabItem';
         RateAmount:         "1.5",
         PaidCredits:        "20.0"
         GrantedCredits:     "10.0",
+        Currency:           "USD",
         ExpirationDate:     "2022-07-07",
         ExternalCustomerId: "12345",
       }
@@ -132,6 +136,7 @@ import TabItem from '@theme/TabItem';
     "rate_amount": "1.5",
     "paid_credits": "20.0",
     "granted_credits": "10.0",
+    "currency":"USD",
     "expiration_date": "2022-07-07",
     "external_customer_id": "12345"
   }
@@ -144,6 +149,7 @@ import TabItem from '@theme/TabItem';
 | rate_amount | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Rate between credits and the amount in given currency |
 | paid_credits | String &nbsp &nbsp &nbsp<Optional>**Optional (This field is required only if there is no granted credits)**</Optional> | Paid credits. |
 | granted_credits | String &nbsp &nbsp &nbsp<Optional>**Optional (This field is required only if there is no paid credits)**</Optional> | Granted (free) credits. |
+| currency | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | 	Currency. |
 | expiration_date | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Date that determines when the wallet will expire. |
 | external_customer_id | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | External customer ID. |
 ## Responses


### PR DESCRIPTION
Hi Guys

Ran into this issue when creating a wallet against a new customer account.   The create wallet documentation excludes the currency argument which is defined as not null in the wallet object description.

**See error returned by lago-api in console :**

[c523ac3e-9351-4eae-b5a5-504c1511be3a] ActiveRecord::NotNullViolation (PG::NotNullViolation: ERROR:  null value in column "currency" of relation "wallets" violates not-null constraint
lago-api      | DETAIL:  Failing row contains (9c7f2c2e-e9ad-460a-a7d8-fa52ddab9b02, 4346a882-d999-450f-a60d-6528e59d68ce, 0, null, test, 1.00000, 0.00000, 0.00000, 0.00000, null, null, null,

Currency is a required argument when creating a wallet.   If currency is not included a http 500 is returned.

