### PR TITLE
Update top-up.mdx

### DIFF
--- a/docs/api/13_wallets/top-up.mdx
+++ b/docs/api/13_wallets/top-up.mdx
@@ -26,7 +26,7 @@ import TabItem from '@theme/TabItem';
     --header "Authorization: Bearer $API_KEY" \
     --header 'Content-Type: application/json' \
     --data-raw '{
-      "wallet": {
+      "wallet_transaction": {
         "wallet_id": "12345",
         "paid_credits": "20.0",
         "granted_credits": "10.0"


### PR DESCRIPTION
TYPO:  The curl example incorrectly uses "wallet" instead of "wallet_transaction" as the parent item name of the object submitted in the request body. Corrected the typo ;)