### PR TITLE
feat(delete_bm): Update response for billable metric deletion

### DIFF
--- a/docs/api/02_billable_metrics/billable-metric-object.mdx
+++ b/docs/api/02_billable_metrics/billable-metric-object.mdx
@@ -18,7 +18,9 @@ This object represents a billable metric.<br></br>
     "aggregation_type": "sum_agg",
     "field_name": "amount_sum",
     "created_at": "2022-04-29T08:59:51Z",
-    "group": {}
+    "group": {},
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0
   }
 }
 ```
@@ -33,6 +35,8 @@ This object represents a billable metric.<br></br>
 | **field_name** &nbsp &nbsp <Type>String</Type> | Field name used in events. |
 | **created_at** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> &nbsp &nbsp <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date of billable metric creation. |
 | **group** &nbsp &nbsp <Type>Object</Type> | Group (one or two dimensions) for pricing differently the billable metric |
+| **active_subscriptions_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of active subscription attached to the billable metric. This field can be used to know the impact of deleting this billable metric. |
+| **draft_invoices_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of draft invoices containing a subscription attached to the billable metric. This field can be used to know the impact of deleting this billable metric. |
 
 
 export const Type = ({children, color}) => (

--- a/docs/api/02_billable_metrics/destroy-billable-metric.mdx
+++ b/docs/api/02_billable_metrics/destroy-billable-metric.mdx
@@ -122,19 +122,6 @@ import TabItem from '@theme/TabItem';
 
   The `billable_metric` was not found.
   </TabItem>
-
-  <TabItem value="405" label="HTTP 405">
-
-  ```json
-  {
-    "status": 405,
-    "error": "Method Not Allowed",
-    "code": "attached_to_an_active_subscription"
-  }
-  ```
-
-  Billable metric that is attached to an active subscription cannot be destroyed.
-  </TabItem>
 </Tabs>
 
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric response:
- `active_subscriptions_count`
- `draft_invoices_count`
It also removes the 405 response from the delete query

These fields are used to know the impact of deleting billable metric.