### PR TITLE
feat(delete_plan): Add subscription and invoice counters to plans

### DIFF
--- a/docs/api/03_plans/destroy-plan.mdx
+++ b/docs/api/03_plans/destroy-plan.mdx
@@ -122,19 +122,6 @@ import TabItem from '@theme/TabItem';
 
   The `plan` was not found.
   </TabItem>
-
-  <TabItem value="405" label="HTTP 405">
-
-  ```json
-  {
-    "status": 405,
-    "error": "Method Not Allowed",
-    "code": "attached_to_an_active_subscription"
-  }
-  ```
-
-  Plan that is attached to an active subscription cannot be destroyed.
-  </TabItem>
 </Tabs>
 
 

--- a/docs/api/03_plans/plan-object.mdx
+++ b/docs/api/03_plans/plan-object.mdx
@@ -22,6 +22,8 @@ This object represents a plan.<br></br>
     "trial_period": 3.0,
     "pay_in_advance": true,
     "bill_charges_monthly": true,
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0,
     "charges": [
       {
         "lago_id": "27f12d13-4ae0-437b-b822-8771bcd62e3a",
@@ -122,6 +124,8 @@ This object represents a plan.<br></br>
 | **trial_period** &nbsp &nbsp <Type>Float</Type> | Number of days for free trial. |
 | **pay_in_advance** &nbsp &nbsp <Type>Boolean</Type> | Value should be `true` for payment in advance and `false` for payment in arrear. |
 | **bill_charges_monthly** &nbsp &nbsp <Type>Boolean</Type> | It should be set to `true` if monthly billing is needed on yearly plan. |
+| **active_subscriptions_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of active subscription attached to the plan. This field can be used to know the impact of deleting this plan. |
+| **draft_invoices_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of draft invoices containing a subscription attached to the plan. This field can be used to know the impact of deleting this plan. |
 
 
 ### Charge attributes


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to add two counters in the plan response:
- `active_subscription_count`
- `draft_invoice_count`