### PR TITLE
feat(delete_customer): Remove 405 errors for delete customers and cou…

### DIFF
--- a/docs/api/04_customers/destroy-customer.mdx
+++ b/docs/api/04_customers/destroy-customer.mdx
@@ -163,19 +163,6 @@ namespace Example
 
   The `customer` was not found.
   </TabItem>
-
-  <TabItem value="405" label="HTTP 405">
-
-  ```json
-  {
-    "status": 405,
-    "error": "Method Not Allowed",
-    "code": "attached_to_an_active_subscription"
-  }
-  ```
-
-  Customer that is attached to an active subscription cannot be destroyed.
-  </TabItem>
 </Tabs>
 
 export const Required = ({children, color}) => (

--- a/docs/api/09_coupons/destroy-coupon.mdx
+++ b/docs/api/09_coupons/destroy-coupon.mdx
@@ -163,19 +163,6 @@ namespace Example
 
   The `coupon` was not found.
   </TabItem>
-
-  <TabItem value="405" label="HTTP 405">
-
-  ```json
-  {
-    "status": 405,
-    "error": "Method Not Allowed",
-    "code": "attached_to_an_active_customer"
-  }
-  ```
-
-  Coupon that is attached to an active customer cannot be destroyed.
-  </TabItem>
 </Tabs>
 
 


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR remove the `HTTP 405` errors on delete customer and delete coupons actions