### PR TITLE
doc(fee): Add fee rounding rules

### DIFF
--- a/docs/api/07_customer_usage/customer-usage.mdx
+++ b/docs/api/07_customer_usage/customer-usage.mdx
@@ -172,7 +172,7 @@ try {
 | Attributes | Type | Description |
 | ---------- | ---- | ----------- |
 | external_customer_id | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Customer unique identifier in your application |
-| external_subscription_id | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Subscription unique identifier in your application |
+| external_subscription_id | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Subscription unique identifier in your application |
 
 ## Responses
 
@@ -226,3 +226,43 @@ try {
   Customer is not attached to an active subscription.
   </TabItem>
 </Tabs>
+
+
+export const Required = ({children, color}) => (
+  <span
+    style={{
+      color: "#DC3309",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Optional = ({children, color}) => (
+  <span
+    style={{
+      color: "#8C95A6",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Comment = ({children, color}) => (
+  <span
+    style={{
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);
+
+export const PostEndpoint = ({children, color}) => (
+  <span
+    style={{
+      color: "#008559",
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);

--- a/docs/guide/10_invoicing/fees.md
+++ b/docs/guide/10_invoicing/fees.md
@@ -80,3 +80,17 @@ The fee object is embedded in the invoice object, as illustrated below.
   }
 }
 ```
+
+## Rounding rules for Lago fees
+Lago rounds the Lago fees to the nearest unit (e.g., cents). For example, if the fee is 0.175, Lago will round up to 0.18. If the fee is 0.174, Lago will round down to 0.17.
+
+The tax rate is calculated at the item level and the total amount is rounded after summing all the items on the invoice.
+
+|                      | Amount | Tax rate | Tax amount | Total amount (before rounding) | Total amount (after rounding) | Total |
+|----------------------|--------|----------|------------|--------------------------------|-------------------------------|-------|
+| Line item 1          | $0.17  | 20%      | $0.034     |                                |                               |       |
+| Line item 2          | $4.46  | 20%      | $0.892     |                                |                               |       |
+| Subtotal (excl. tax) | $4.63  |          |            |                                |                               |       |
+| Tax amount           |        |          | $0.926     |                                |                               |       |
+| Subtotal (incl. tax) |        |          |            | $5.556                         | $5.56                         |       |
+| Total                |        |          |            |                                |                               | $5.56 |


### PR DESCRIPTION
## Context
Back-end improved and implemented a better rounding calculation system across the app.

## Description
Updating the doc to explain how the rounding calculation is done inside Lago system