### PR TITLE
feat (customer metadata): Add API docs for customer metadata

### DIFF
--- a/docs/api/04_customers/create-update-customer.mdx
+++ b/docs/api/04_customers/create-update-customer.mdx
@@ -381,7 +381,7 @@ try {
 }
 ```
 :::info
-If the customer already exists, the call will work as an update
+If the customer already exists, this request will trigger an update.
 :::
 
 | Attributes | Type | Description |
@@ -420,10 +420,14 @@ If the customer already exists, the call will work as an update
 
 | Attributes | Type | Description |
 | -----------| -----| ----------- |
-| key | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object key
-| value | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object value
-| display_in_invoice | Boolean &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Field that determines if metadata pair will be visible on invoice
-| id | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object identifier. This field is needed only for `update` action
+| key | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object key |
+| value | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object value |
+| display_in_invoice | Boolean &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Field that determines whether the metadata key-value pair will be visible on invoices |
+| id | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object identifier - only required when updating metadata |
+
+:::caution
+When updating a customer, if an existing `metadata.id` is not included in the payload, then the corresponding key-value pair will be deleted.
+:::
 
 ## Responses
 

--- a/docs/api/04_customers/create-update-customer.mdx
+++ b/docs/api/04_customers/create-update-customer.mdx
@@ -51,7 +51,15 @@ import TabItem from '@theme/TabItem';
           "sync_with_provider": true,
           "document_locale": "fr",
           "vat_rate": 12.5
-        }
+        },
+        "metadata": [
+          {
+            "id": "__METADATA_ID__",
+            "key": "Name",
+            "value": "John",
+            "display_in_invoice": true
+          }
+        ]
       }
     }'
   ```
@@ -65,6 +73,12 @@ import TabItem from '@theme/TabItem';
   from lago_python_client.models import Customer, CustomerBillingConfiguration
 
   client = Client(api_key='__YOUR_API_KEY__')
+
+  metadata_object = Metadata(
+    display_in_invoice=True,
+    key='key',
+    value='value'
+  )
 
   customer = Customer(
     external_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
@@ -91,7 +105,8 @@ import TabItem from '@theme/TabItem';
       sync_with_provider=true,
       document_locale="fr",
       vat_rate=12.5
-    )
+    ),
+    metadata=MetadataList(__root__=[metadata_object])
   )
 
   client.customers().create(customer)
@@ -133,7 +148,14 @@ import TabItem from '@theme/TabItem';
       true, // syncWithProvider
       "fr", // documentLocale
       None  // vatRate
-    )
+    ),
+    [
+      new CustomerMetadata({
+        key: 'key',
+        value: 'value',
+        displayInInvoice: true
+      })
+    ]
   )
   await client.createCustomer(customer);
   ```
@@ -171,7 +193,14 @@ import TabItem from '@theme/TabItem';
       sync_with_provider: true,
       document_locale: "fr",
       vat_rate: 12.5
-    }
+    },
+    metadata: [
+      {
+        key: 'key',
+        value: 'value',
+        display_in_invoice: true
+      }
+    ]
   )
   ```
 
@@ -210,7 +239,14 @@ import TabItem from '@theme/TabItem';
           SyncWithProvider: true,
           DocumentLocale: "fr",
           VatRate: 20.0
-        }
+        },
+        Metadata: [
+          &CustomerMetadataInput{
+            Key: "Key",
+            Value: "Value",
+            DisplayInInvoice: true
+          }
+        ]
       }
 
       customer, err := lagoClient.Customer().Create(customerInput)
@@ -332,7 +368,15 @@ try {
       "sync_with_provider": true,
       "document_locale": "fr",
       "vat_rate": 12.5
-    }
+    },
+    "metadata": [
+      {
+        "id": "__METADATA LAGO ID__",
+        "key": "Key example",
+        "value": "Value example",
+        "display_in_invoice": true
+      }
+    ]
   }
 }
 ```
@@ -371,6 +415,15 @@ If the customer already exists, the call will work as an update
 | sync_with_provider | Boolean &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Set to `true` if you want to create the customer record in the provider's system. Only applies when `provider_customer_id` is `null` and `sync_with_provider` is set to `true`. Default value: `false`
 | document_locale | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Document locale in ISO 639-1 format - [learn more](../resources/locales)
 | vat_rate | Float &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Custom VAT applied to the customer.<br></br> It will override the one defined at organization level |
+
+### Metadata
+
+| Attributes | Type | Description |
+| -----------| -----| ----------- |
+| key | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object key
+| value | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object value
+| display_in_invoice | Boolean &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Field that determines if metadata pair will be visible on invoice
+| id | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Metadata object identifier. This field is needed only for `update` action
 
 ## Responses
 

--- a/docs/api/04_customers/customer-object.mdx
+++ b/docs/api/04_customers/customer-object.mdx
@@ -43,7 +43,16 @@ It lets you create a customer, but also track usage and create invoices for the 
       "sync_with_provider": true,
       "document_locale": "fr",
       "vat_rate": 12.5
-    }
+    },
+    "metadata": [
+      {
+        "lago_id": "27f12d13-4ae0-437b-b822-8771bcd62e3a",
+        "key": "Account manager",
+        "value": "John Doe",
+        "display_in_invoice": true,
+        "created_at": "2022-04-29T08:59:51Z"
+      }
+    ]
   }
 }
 ```
@@ -82,6 +91,15 @@ It lets you create a customer, but also track usage and create invoices for the 
 | document_locale &nbsp &nbsp <Type>String</Type><br></br><Comment>*ISO 639-1*</Comment> | Language code - [learn more](../resources/locales) |
 | vat_rate &nbsp &nbsp <Type>Float</Type> | Custom VAT rate applied to the customer |
 | sync_with_provider  &nbsp &nbsp <Type>Boolean</Type> | Field that determines whether to create customer in payment provider or not |
+
+## Metadata attributes
+| Attributes | Description |
+| -----------| ----------- |
+| **lago_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifier of the customer metadata object in Lago application. |
+| **created_at** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> &nbsp &nbsp <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date of metadata object creation. |
+| **key** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Key part in metadata pair |
+| **value** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Value part in metadata pair |
+| **display_in_invoice** &nbsp &nbsp <Type>Boolean</Type> | Field that determines if metadata pair will be presented on documents |
 
 export const Type = ({children, color}) => (
   <span


### PR DESCRIPTION
@mathieu-lago Since we share the same endpoint for both create and update probably we will have to separate it somehow due to this change. For `update`, metadata object can have `id` attribute but for `create` there is no `id` parameter... Any idea?