### PR TITLE
doc(Customers): Fix all broken links

### DIFF
--- a/changelog/document-locale.md
+++ b/changelog/document-locale.md
@@ -5,7 +5,7 @@ date: 2023-02-21T11:00
 # Document translation
 PDF files including invoices and credit notes can be generated in different languages.
 
-The [default language](../docs/guide/invoicing/download-invoices#translate-invoices) that is set at the organization level can be overwritten by the [customer's preferred language](../docs/guide/customers#preferred-language).
+The [default language](../docs/guide/invoicing/download-invoices#translate-invoices) that is set at the organization level can be overwritten by the [customer's preferred language](../docs/guide/06_customers/invoice_customer.md#preferred-language)
 
 In the API, the `document_locale` attribute determines the language of the documents.
 

--- a/changelog/timezones.md
+++ b/changelog/timezones.md
@@ -18,7 +18,7 @@ It can also be set through the API using this [endpoint](../docs/api/organizatio
 
 The organization's timezone applies to all customers by default and determines when billing periods start and end (i.e. when invoices should be generated). It is also the reference timezone for most views and lists in the app.
 
-The organization's timezone can be overwritten by the customer's timezone ([learn more](../docs/guide/customers/invoice_customer#timezone)).
+The organization's timezone can be overwritten by the customer's timezone ([learn more](../docs/guide/06_customers/invoice_customer.md)).
 
 :::tip
 In the app, you can hover over any date with a dotted underline to see the reference timezones.

--- a/config.json
+++ b/config.json
@@ -20,7 +20,10 @@
     "https://doc.getlago.com/docs/guide/plans/subscription",
     "https://doc.getlago.com/docs/guide/plans/upgrades-downgrades",
 
-    "https://doc.getlago.com/docs/guide/customers",
+    "https://doc.getlago.com/docs/guide/customers/management",
+    "https://doc.getlago.com/docs/guide/customers/metadata",
+    "https://doc.getlago.com/docs/guide/customers/invoice_customer",
+
 
     "https://doc.getlago.com/docs/guide/coupons",
 

--- a/docs/guide/06_customers/invoice_customer.md
+++ b/docs/guide/06_customers/invoice_customer.md
@@ -26,7 +26,7 @@ You can hover over any date in the customer view to see the reference timezones.
 :::
 
 ## Preferred language
-The default language for documents is defined at the organization level ([learn more](../invoicing/download-invoices#translate-invoices). It can be overwritten at the customer level.
+The default language for documents is defined at the organization level [learn more](../invoicing/download-invoices#translate-invoices). It can be overwritten at the customer level.
 
 To set the customer's preferred language:
 1. Access the **"Customers"** section via the side menu;

--- a/docs/guide/98_testing-integration.md
+++ b/docs/guide/98_testing-integration.md
@@ -37,7 +37,7 @@ To create a plan through the user interface:
 To create a customer through the user interface:
 1. In the side menu, select **"Customers"**;
 2. Click **"Add a customer"** in the upper right corner;
-3. Fill in the form in the pop-up window ([learn more about customers](./customers)); and
+3. Fill in the form in the pop-up window ([learn more about customers](./06_customers/)); and
 4. Click **"Add customer"** to save.
 
 You can also create customers through the API, as described in the [documentation](../api/customers/create-update-customer).


### PR DESCRIPTION
## Context
After releasing the documentation for Customers metadata, the deploy failed because of some broken links

## Description
Fix the broken links in the documentation