### PR TITLE
doc(Ressources): Add nb as locale in doc

### DIFF
--- a/docs/api/99_resources/locales.mdx
+++ b/docs/api/99_resources/locales.mdx
@@ -10,6 +10,7 @@ List of accepted locales for documents (ISO 639-1).
 |--|--|
 | `en` | English |
 | `fr` | French |
+| `nb` | Norwegian (Bokmål) |
 
 ## How to add a new language
 


### PR DESCRIPTION
## Context
Lago is supporting the locale Norwegian (Bokmål), we should update our documentation.

## Description
Update of docs/api/ressources/locales and add Norwegian (Bokmål) in the list of locales supported by Lago. 