### PR TITLE
feat(bm): Expose count of attached plans

### DIFF
--- a/docs/api/02_billable_metrics/billable-metric-object.mdx
+++ b/docs/api/02_billable_metrics/billable-metric-object.mdx
@@ -20,7 +20,8 @@ This object represents a billable metric.<br></br>
     "created_at": "2022-04-29T08:59:51Z",
     "group": {},
     "active_subscriptions_count": 0,
-    "draft_invoices_count": 0
+    "draft_invoices_count": 0,
+    "plans_count": 0
   }
 }
 ```
@@ -37,6 +38,7 @@ This object represents a billable metric.<br></br>
 | **group** &nbsp &nbsp <Type>Object</Type> | Group (one or two dimensions) for pricing differently the billable metric |
 | **active_subscriptions_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of active subscription attached to the billable metric. This field can be used to know the impact of deleting this billable metric. |
 | **draft_invoices_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of draft invoices containing a subscription attached to the billable metric. This field can be used to know the impact of deleting this billable metric. |
+| **plans_count** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Count of plans attachedto the billable metric. This field can be used to know if aggregation attributes can be edited. |
 
 
 export const Type = ({children, color}) => (

--- a/docs/api/03_plans/plan-object.mdx
+++ b/docs/api/03_plans/plan-object.mdx
@@ -28,6 +28,7 @@ This object represents a plan.<br></br>
       {
         "lago_id": "27f12d13-4ae0-437b-b822-8771bcd62e3a",
         "lago_billable_metric_id": "b09ce382-ce87-4da4-89f2-78b2060689fc",
+        "billable_metric_code": "bm_code",
         "created_at": "2022-08-24T14:58:59Z",
         "charge_model": "standard",
         "group_properties": [
@@ -42,6 +43,7 @@ This object represents a plan.<br></br>
       {
         "lago_id": "e530f658-c06a-44bb-a413-1fbe3796adb4",
         "lago_billable_metric_id": "b09ce382-ce87-4da4-89f2-78b2060689fc",
+        "billable_metric_code": "bm_code",
         "created_at": "2022-08-24T14:58:59Z",
         "charge_model": "graduated",
         "properties": {
@@ -64,6 +66,7 @@ This object represents a plan.<br></br>
       {
         "lago_id": "108051fc-c71b-47b4-bd86-47436ea6b639",
         "lago_billable_metric_id": "b09ce382-ce87-4da4-89f2-78b2060689fc",
+        "billable_metric_code": "bm_code",
         "created_at": "2022-08-24T14:58:59Z",
         "charge_model": "package",
         "properties": {
@@ -75,6 +78,7 @@ This object represents a plan.<br></br>
       {
         "lago_id": "88b878e2-4ba4-4f37-98c9-ca8522a9e574",
         "lago_billable_metric_id": "b09ce382-ce87-4da4-89f2-78b2060689fc",
+        "billable_metric_code": "bm_code",
         "created_at": "2022-08-24T14:58:59Z",
         "charge_model": "percentage",
         "properties": {
@@ -87,6 +91,7 @@ This object represents a plan.<br></br>
       {
         "lago_id": "e530f658-c06a-44bb-a413-1fbe3796555",
         "lago_billable_metric_id": "b09ce382-ce87-4da4-89f2-78b2060689fc",
+        "billable_metric_code": "bm_code",
         "created_at": "2022-08-24T14:58:59Z",
         "charge_model": "volume",
         "properties": {
@@ -133,6 +138,7 @@ This object represents a plan.<br></br>
 | -----------| ----------- |
 | **lago_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifier of the charge in Lago application. |
 | **lago_billable_metric_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifier of the related billable metric in Lago application. |
+| **billable_metric_code** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not Null</NotNullable> | Code identifying the billable metric. |
 | **created_at** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> &nbsp &nbsp <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date of charge creation. |
 | **charge_model** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable><br></br> | Charge model used in event calculations. <br></br> <details><summary>**Possible values**</summary><div>- `standard`<br></br>- `graduated`<br></br>- `package`<br></br>- `percentage`<br></br>- `volume`<div></div></div></details> |
 | **properties** &nbsp &nbsp <Type>JSON</Type> | Extra data. This field will depend on selected charge_model |


### PR DESCRIPTION
## Context

Plans edition has some issue if you update some properties of a billable metric, especially if you change groups definition or aggregation type :

"After the billable metric edition, new dimensions are created with new group_id that do not match the ones in the plans already defined"

## Description

This PR exposes a new `plans_count` field in the `BillableMetric` response type to let the API users know if the BM is editable.

Related to https://github.com/getlago/lago-api/pull/914
