### PR TITLE
feat(instant_charge): Document API route to estimate instant fees amount

### DIFF
--- a/docs/api/06_events/estimate-instant.mdx
+++ b/docs/api/06_events/estimate-instant.mdx
@@ -1,0 +1,352 @@
+---
+sidebar_position: 7
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Estimate fees for an instant charge
+
+TODO
+
+## Route
+
+```curl title="POST"
+api/v1/events/estimate_fees
+```
+
+## Usage
+
+<Tabs groupId="prog-language">
+  <TabItem value="curl" label="Curl" default>
+
+  ```bash
+  LAGO_URL="https://api.getlago.com"
+  API_KEY="__YOUR_API_KEY__"
+
+  curl --location --request POST "$LAGO_URL/api/v1/events/estimate_fees" \
+  --header "Authorization: Bearer $API_KEY" \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+        "event": {
+            "external_customer_id": "__YOUR_CUSTOMER_ID__",
+            "external_subscription_id": "__YOUR_SUBSCRIPTION_ID__",
+            "code": "__EVENT_CODE__",
+            "properties": {
+              "custom_field": 12,
+            }
+        }
+    }'
+  ```
+
+  </TabItem>
+
+  <TabItem value="python" label="Python">
+
+  ```python
+  from lago_python_client import Client
+  from lago_python_client.models import Event
+
+  client = Client(api_key='__YOUR_API_KEY__')
+
+  event = Event(
+    external_customer_id="__UNIQUE_ID__",
+    external_subscription_id="__UNIQUE_ID__",
+    code="code",
+  )
+
+  client.events().estimate_fees(event)
+  ```
+
+  </TabItem>
+
+  <TabItem value="ruby" label="Ruby">
+
+  ```ruby
+  require 'lago-ruby-client'
+
+  client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+
+  client.events.estimate_fees(
+    external_customer_id: "__CUSTOMER_ID__",
+    external_subscription_id: "__SUBSCRIPTION_ID__",
+    code: "code",
+    properties: {
+      custom_field: 12,
+    }
+  )
+  ```
+
+  </TabItem>
+
+  <TabItem value="javascript" label="Javascript">
+
+  ```javascript
+  import { Client, getLagoError } from 'lago-javascript-client';
+
+  const lagoClient = Client('__YOUR_API_KEY__');
+
+  try {
+      const { data } = await lagoClient.events.eventEstimateFees(estimateEvent);
+  } catch (error) {
+      const lagoError = await getLagoError<typeof lagoClient.events.eventEstimateFees>(error);
+  }
+  ```
+
+  </TabItem>
+
+  <TabItem value="go" label="Go">
+
+  ```go
+    import "fmt"
+    import "github.com/getlago/lago-go-client"
+
+    func main() {
+      lagoClient := lago.New().SetApiKey("__YOUR_API_KEY__")
+
+      eventEstimateInput := &lago.EventEstimateFeesInput{
+        ExternalCustomerID: "vincent_12345",
+        ExternalSubscriptionID: "1dbe81ce-b092-401c-a00b-314292e17a98",
+        Code:          "code",
+        Properties: map[string]string{
+          "nbusers": "12",
+        },
+      }
+
+      err := lagoClient.Event().EstimateFees(eventEstimateInput)
+      if err != nil {
+        // Error is *lago.Error
+        panic(err)
+      }
+    }
+  ```
+
+  </TabItem>
+
+  <TabItem value="csharp" label="C#">
+
+  ```csharp
+  using System.Collections.Generic;
+  using System.Diagnostics;
+  using Org.OpenAPITools.Api;
+  using Org.OpenAPITools.Client;
+  using Org.OpenAPITools.Model;
+
+  namespace Example
+  {
+    public class CreateEventExample
+    {
+      public static void Main()
+      {
+        Configuration.Default.BasePath = "https://api.getlago.com/api/v1";
+        // Configure HTTP bearer authorization: bearerAuth
+        Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
+
+        var apiInstance = new EventsApi(Configuration.Default);
+        // EventEstimateFeesInput | Event estimate payload
+        var eventEstimateInput = new EventEstimateFeesInput();
+
+        try
+        {
+          // Create a new event
+          apiInstance.EventEstimateFees(eventEstimateInput);
+        }
+        catch (ApiException e)
+        {
+          Debug.Print("Exception when calling EventsApi.EventEstimateFees: " + e.Message );
+          Debug.Print("Status Code: "+ e.ErrorCode);
+          Debug.Print(e.StackTrace);
+        }
+      }
+    }
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+  ```php
+  require_once(__DIR__ . '/vendor/autoload.php');
+
+  // Configure Bearer authorization: bearerAuth
+  $config = OpenAPI\Client\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');
+
+
+  $apiInstance = new OpenAPI\Client\Api\EventsApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client(),
+    $config
+  );
+  $event_estimate_input = new \OpenAPI\Client\Model\EventEstimateFeesInput(); // \OpenAPI\Client\Model\EventEstimateFeesInput | Event estimage fees payload
+
+  try {
+      $apiInstance->eventEstimateFees($event_input);
+  } catch (Exception $e) {
+      echo 'Exception when calling EventsApi->eventEstimateFees: ', $e->getMessage(), PHP_EOL;
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Arguments
+
+```json
+{
+  "event": {
+    "code": "__EVENT_CODE__",
+    "external_customer_id": "__CUSTOMER_ID__",
+    "external_subscription_id": "__SUBSCRIPTION_ID__",
+    "properties": {
+      "custom_field": 12
+    }
+  }
+}
+```
+
+| Attributes | Type | Description |
+| -----------| -----| ----------- |
+| **code** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Code identifying the type of the event.<br></br> It should match the `code` property of one of your active billable metrics attached to an `instant` charge. |
+| **external_customer_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Unique customer ID in your application.<br></br>If `external_subscription_id` is not given, `external_customer_id` is required if there is only one subscription attached to customer. For multiple subscriptions per customer this attribute is not enough |
+| **external_subscription_id** | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Unique subscription ID in your application.<br></br>`external_subscription_id` is required if the customer has multiple subscriptions or if `external_customer_id` is not provided (in case there's only one subscription) |
+| **properties** | JSON &nbsp &nbsp &nbsp<Variable>**Variable**</Variable> | Extra data to use for the event aggregation.<br></br>When mandatory, it should contains the `field_name` configured at billable metric level as `key` and any value as field `value`. |
+
+### Content of the event properties object
+
+| Attributes | Types | Description |
+|--|--|--|
+| *field_name* **(*)** | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | **(*)** Key must be the `field_name` configured at billable metric level. |
+
+## Responses
+
+<Tabs>
+  <TabItem value="200" label="HTTP 200" default>
+
+  The event estimate was succesfuly estimated.
+
+  Returns a list of [fee](../fees/fee-object) objects.
+
+  </TabItem>
+  <TabItem value="400" label="HTTP 400">
+
+  ```json
+  {
+    "status": 400,
+    "error": "Bad Request",
+  }
+  ```
+
+  The `event` json root is not present in the request body.
+
+  </TabItem>
+  <TabItem value="401" label="HTTP 401">
+
+  ```json
+  {
+    "status": 401,
+    "error": "Unauthorized",
+  }
+  ```
+
+  Access to the API end point is unhautorized.
+
+  **Possible reasons are:**
+  - The `Authorization` header is missing
+  - The `Authorization` header does not contain the API key
+  - The Api key is invalid or expired
+
+
+  </TabItem>
+  <TabItem value="404" label="HTTP 404">
+
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "code": "error"
+  }
+  ```
+
+  **Possible errors:**
+
+  | error | description |
+  |--|--|
+  | `customer_not_found` | The `external_customer_id` does not match an existing customer. |
+  | `subscription_not_found` | The `external_subscription_id` does not match an existing subscription. |
+  | `billable_metric_not_found` | The `code` does not match an existing billable metric code. |
+
+  </TabItem>
+  <TabItem value="422" label="HTTP 422">
+
+  ```json
+  {
+    "status": 422,
+    "error": "Unprocessable entity",
+    "code": "validation_errors",
+    "error_details": {
+      "field": ["error"]
+    }
+  }
+  ```
+
+  **Possible errors:**
+
+  | field | error | description |
+  |--|--|--|
+  | `transaction_id` | `value_is_mandatory` | `transaction_id` value is missing |
+  | `code` | `value_is_mandatory` | `code` value is missing |
+  | `external_subscription_id` | `value_is_mandatory` | `external_subscription_id` is missing |
+  | `properties` | `value_is_not_valid_number` | Provided property is not a number |
+
+  </TabItem>
+</Tabs>
+
+export const Required = ({children, color}) => (
+  <span
+    style={{
+      color: "#DC3309",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Optional = ({children, color}) => (
+  <span
+    style={{
+      color: "#8C95A6",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Comment = ({children, color}) => (
+  <span
+    style={{
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);
+
+export const PostEndpoint = ({children, color}) => (
+  <span
+    style={{
+      color: "#008559",
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Variable = ({children, color}) => (
+  <span
+    style={{
+      color: "#422CC1",
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);

--- a/docs/api/06_events/estimate-instant.mdx
+++ b/docs/api/06_events/estimate-instant.mdx
@@ -44,10 +44,7 @@ api/v1/events/estimate_fees
   <TabItem value="python" label="Python">
 
   ```python
-  from lago_python_client import Client
   from lago_python_client.models import Event
-
-  client = Client(api_key='__YOUR_API_KEY__')
 
   event = Event(
     external_customer_id="__UNIQUE_ID__",
@@ -55,7 +52,7 @@ api/v1/events/estimate_fees
     code="code",
   )
 
-  client.events().estimate_fees(event)
+  client.events.estimate_fees(event)
   ```
 
   </TabItem>

--- a/docs/api/06_events/estimate-instant.mdx
+++ b/docs/api/06_events/estimate-instant.mdx
@@ -7,8 +7,6 @@ import TabItem from '@theme/TabItem';
 
 # Estimate fees for an instant charge
 
-TODO
-
 ## Route
 
 ```curl title="POST"

--- a/docs/api/11_fees/fee-object.mdx
+++ b/docs/api/11_fees/fee-object.mdx
@@ -10,12 +10,16 @@ This object represents a line item of an invoice, handling amount, billed units 
 
 ```json
 {
-  "lago_id": "6be23c42-47d2-45a3-9770-5b3572f225c3",
-  "lago_group_id": "5b4881e3-b451-472e-9e03-d99379550743",
+  "lago_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+  "lago_group_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+  "lago_invoice_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+  "external_subscription_id": "external_id",
   "item": {
     "type": "subscription",
     "code": "plan_code",
-    "name": "Plan"
+    "name": "Plan",
+    "lago_item_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    "item_type": "Subscription"
   },
   "amount_cents": 100,
   "amount_currency": "EUR",
@@ -26,7 +30,12 @@ This object represents a line item of an invoice, handling amount, billed units 
   "units": "0.32",
   "events_count": 23,
   "from_date": "2022-04-29T08:59:51Z",
-  "to_date": "2022-05-29T08:59:51Z"
+  "to_date": "2022-05-29T08:59:51Z",
+  "payment_status": "pending",
+  "created_at": "2022-08-24T14:58:59Z",
+  "succeeded_at": "2022-08-24T14:58:59Z",
+  "failed_at": "2022-08-24T14:58:59Z",
+  "refunded_at": "2022-08-24T14:58:59Z"
 }
 ```
 
@@ -34,7 +43,6 @@ This object represents a line item of an invoice, handling amount, billed units 
 | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **lago_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>               | Unique identifer of the fee in Lago application                                                                                                                                                                                                                                      |
 | **lago_group_id** &nbsp &nbsp <Type>String</Type>                                                         | Unique identifer of the group in Lago application                                                                                                                                                                                                                                    |
-| **item** &nbsp &nbsp <Type>JSON</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>                    | Item attached to the fee. <br/><br/>**Always have 3 attributes:**<br/><br/>- `type`: `charge` or `subscription`<br/><br/>- `code`: Code of the plan or of the billable metric attached to the fee.<br/><br/>- `name`: Name of the plan of of the billable metric attached to the fee |
 | **amount_cents** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>         | Amount in cents of the fee, VAT excluded                                                                                                                                                                                                                                             |
 | **amount_currency** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>       | Currency of the amount                                                                                                                                                                                                                                                               |
 | **vat_amount_cents** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>     | VAT amount in cents                                                                                                                                                                                                                                                                  |
@@ -43,8 +51,25 @@ This object represents a line item of an invoice, handling amount, billed units 
 | **total_amount_currency** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Currency of the total amount                                                                                                                                                                                                                                                         |
 | **units** &nbsp &nbsp <Type>String (Decimal)</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>       | Units used to charge the customer                                                                                                                                                                                                                                                    |
 | **events_count** &nbsp &nbsp <Type>Integer</Type>                                                         | Number of events                                                                                                                                                                                                                                                                     |
-| **from_date** &nbsp &nbsp <Type>String</Type><br/>/<br/><Comment>_ISO 8601 date_</Comment>                | Beginning date of the period that the fee covers. <br/><br/> <details>Only applies to `subscription` and `charge` fees</details>                                                                                                                                                     |
-| **to_date** &nbsp &nbsp <Type>String</Type><br/></br/><Comment>_ISO 8601 date_</Comment>                  | Ending date of the period that the fee covers. <br/><br/> <details>Only applies to `subscription` and `charge` fees</details>                                                                                                                                                        |
+| **from_date** &nbsp &nbsp <Type>String (ISO 8601 date)</Type>                                             | Beginning date of the period that the fee covers. <br/><br/> <details>Only applies to `subscription` and `charge` fees</details>                                                                                                                                                     |
+| **to_date** &nbsp &nbsp <Type>String (ISO 8601 date)</Type>                                               | Ending date of the period that the fee covers. <br/><br/> <details>Only applies to `subscription` and `charge` fees</details>                                                                                                                                                        |
+| **payment_status** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>        | Status of the payment. <br></br> <details><summary>**Possible values**</summary><div>- `pending`<br></br>- `succeeded`<br></br>- `failed`<br></br>- `refunded`<div></div></div></details> |
+| **created_at**&nbsp &nbsp <Type>String (ISO 8601 datetime)</Type>&nbsp &nbsp <NotNullable>Not null</NotNullable>| Date and time of creation of the credit note in UTC |
+| **succeeded_at**&nbsp &nbsp <Type>String (ISO 8601 datetime)</Type>                                       | Date and time in UTC of the payment success. |
+| **failed_at** <Type>String (ISO 8601 datetime)</Type>                                                     | Date and time in UTC of the payment failure. |
+| **refunded_at** <Type>String (ISO 8601 datetime)</Type>                                                   | Date and time in UTC of the payment refund.  |
+| **item** &nbsp &nbsp <Type>JSON</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable>                    | [Item](#item-object) attached to the fee |
+
+## Item object
+
+| Attributes | Description |
+| -----------| ----------- |
+| **type** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Type of fee.<br></br> <details><summary>**Possible values**</summary><div>- `add_on`<br></br>- `charge`<br></br>- `credit`<br></br>- `instant_charge`<br></br>- `subscription`<div></div></div></details> |
+| **code** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Code of item.<br></br> <details><summary>**Possible values**</summary><div>- `add_on`: code of the Add-On<br></br>- `charge`: code of the billable metric<br></br>- `credit`: `credit`<br></br>- `instant_charge`: code of the billable metric<br></br>- `subscription`: code of the plan<div></div></div></details> |
+| **name** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Name of item.<br></br> <details><summary>**Possible values**</summary><div>- `add_on`: name of the Add-On<br></br>- `charge`: name of the billable metric<br></br>- `credit`: `credit`<br></br>- `instant_charge`: name of the billable metric<br></br>- `subscription`: name of the plan<div></div></div></details> |
+| **lago_item_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifier of the item.<br></br> <details><summary>**Possible values**</summary><div>- `add_on`: Lago identifier of the Add-On<br></br>- `charge`: Lago identifier of the billable metric<br></br>- `credit`: Lago identifier of the wallet transaction<br></br>- `instant_charge`: Lago identifier of the billable metric<br></br>- `subscription`: Lago identifier of the subscription<div></div></div></details> |
+| **item_type** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Type of the fee item<br></br> <details><summary>**Possible values**</summary><div>- `add_on`: `AddOn`<br></br>- `charge`: `BillableMetric`<br></br>- `credit`: `WalletTransaction`<br></br>- `instant_charge`: `BillableMetric`<br></br>- `subscription`: `Subscription`<div></div></div></details> |
+
 
 export const Type = ({ children, color }) => (
   <span

--- a/docs/api/11_fees/get-all-fees.mdx
+++ b/docs/api/11_fees/get-all-fees.mdx
@@ -1,0 +1,156 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Get all fees
+
+## Route
+
+```curl title="GET"
+/api/v1/fees?page=2&per_page=20&external_customer_id=hooli_1234
+```
+
+## Usage
+
+<Tabs groupId="prog-language">
+  <TabItem value="curl" label="Curl" default>
+
+  ```bash
+  curl --location --request GET "$LAGO_URL/api/v1/fees?page=2&per_page=20&external_customer_id=hooli_1234" \
+    --header "Authorization: Bearer $API_KEY"
+  ```
+  </TabItem>
+
+  <TabItem value="python" label="Python">
+
+  ```python
+  client.fees.find_all({'per_page': 2, 'page': 1})
+  ```
+  </TabItem>
+
+  <TabItem value="ruby" label="Ruby">
+
+  ```ruby
+  client.fees.get_all({ per_page: 2, page: 3 })
+  ```
+  </TabItem>
+
+  <TabItem value="javascript" label="Javascript">
+
+  ```javascript
+  await client.fees.findAllFees({ per_page: 2, page: 3 });
+  ```
+  </TabItem>
+
+  <TabItem value="go" label="Go">
+
+  ```go
+    feeListInput := &lago.FeeListInput{
+      PerPage: 1,
+      Page: 1,
+      CreatedAtFrom: "2022-01-01T00:00:00Z",
+      CreatedAtTo: "2022-01-01T00:00:00Z",
+    }
+
+    feeResult, err := lagoClient.Fee().GetList(feeListInput)
+    if err != nil {
+      // Error is *lago.Error
+      panic(err)
+    }
+
+    // feeResult is *lago.FeeResult
+    fmt.Println(feeResult)
+  ```
+
+  </TabItem>
+
+  <TabItem value="csharp" label="C#">
+
+  ```csharp
+  var apiInstance = new FeeApi(Configuration.Default);
+  var page = 2;
+  var perPage = 20;
+
+  try
+  {
+    Fee result = apiInstance.FindAllFees(page, perPage);
+  }
+  catch (ApiException e)
+  {
+      Debug.Print("Exception when calling lago API: " + e.Message );
+      Debug.Print("Status Code: "+ e.ErrorCode);
+      Debug.Print(e.StackTrace);
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+  ```php
+  $page = 2;
+  $per_page = 20;
+
+  try {
+    $result = $apiInstance->findAllFees($page, $per_page);
+    print_r($result);
+  } catch (Exception $e) {
+    echo 'Exception when calling lago API: ', $e->getMessage(), PHP_EOL;
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Arguments
+
+| Attributes | Type | Description |
+|--|--|--|
+| per_page | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Number of records per page. |
+| page | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Page number |
+| fee_type | String <Optional>**Optional**</Optional> | Filter results by the fee item type.<br></br> <details><summary>**Possible values**</summary><div>- `add_on`<br></br>- `charge`<br></br>- `credit`<br></br>- `instant_charge`<br></br>- `subscription`<div></div></div></details> |
+| payment_status | String <Optional>**Optional**</Optional> | Filter resilts by the payment status<br></br> <details><summary>**Possible values**</summary><div>- `pending`<br></br>- `succeeded`<br></br>- `failed`<br></br>- `refunded`<div></div></div></details> |
+| external_subscription_id | String <Optional>**Optional**</Optional> |  Filter results by SUBSCRIPTION unique identifier in your application |
+| external_customer_id | String <Optional>**Optional**</Optional> |  Filter results by CUSTOMER unique identifier in your application |
+| billable_metric_code | String <Optional>**Optional**</Optional> | Filter results by the code of the billable metric attached to the fee.<br/>Only applies to `charge` and `instant_charge` types |
+| currency | String <Optional>**Optional**</Optional> | Filter results by the amount currency. See [list](../resources/currencies) for accepted values. |
+| created_at_from | String <Optional>**Optional**</Optional> | Filter results created after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| created_at_to | String <Optional>**Optional**</Optional> | Filter results created before creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| failed_at_from | String <Optional>**Optional**</Optional> | Filter results with payment failure after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| failed_at_to | String <Optional>**Optional**</Optional> | Filter results with payment failure after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| succeeded_at_from | String <Optional>**Optional**</Optional> | Filter results with payment success after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| succeeded_at_to | String <Optional>**Optional**</Optional> | Filter results with payment success after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| refunded_at_from | String <Optional>**Optional**</Optional> | Filter results with payment refund after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+| refunded_at_to | String <Optional>**Optional**</Optional> | Filter results with payment refund after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
+
+
+export const Type = ({children, color}) => (
+  <span
+    style={{
+      color: "#006CFA",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const NotNullable = ({children, color}) => (
+  <span
+    style={{
+      color: "#DC3309",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Comment = ({children, color}) => (
+  <span
+    style={{
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);

--- a/docs/api/11_fees/get-all-fees.mdx
+++ b/docs/api/11_fees/get-all-fees.mdx
@@ -125,6 +125,58 @@ import TabItem from '@theme/TabItem';
 | refunded_at_from | String <Optional>**Optional**</Optional> | Filter results with payment refund after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
 | refunded_at_to | String <Optional>**Optional**</Optional> | Filter results with payment refund after creation date and time in UTC.<br></br>Format example: `2022-02-15T00:00:00Z` |
 
+## Responses
+
+<Tabs>
+  <TabItem value="200" label="HTTP 200" default>
+  Fees were successfully found.
+
+  Returns a list of [fees](./fee-object) objects.
+  </TabItem>
+
+  <TabItem value="401" label="HTTP 401">
+
+  ```json
+  {
+    "status": 401,
+    "error": "Unauthorized"
+  }
+  ```
+
+  Access to the API endpoint is unhautorized.
+
+  **Possible reasons are:**
+  * The `Authorization` header is missing
+  * The `Authorization` header does not contain the API key
+  * The Api key is invalid or expired
+
+
+  </TabItem>
+
+  <TabItem value="422" label="HTTP 422">
+
+  ```json
+  {
+    "status": 422,
+    "error": "Unprocessable entity",
+    "code": "validation_errors",
+    "error_details": {
+      "field": ["error"]
+    }
+  }
+  ```
+
+  **Possible errors:**
+
+  | Field | Code | Description |
+  |--|--|--|
+  | `fee_type` | `value_is_invalid` | Provided `fee_type` does not match an accepted value |
+  | `payment_status` | `value_is_invalid` | Provided `payment_status` does not match an accepted value |
+
+
+  </TabItem>
+</Tabs>
+
 
 export const Type = ({children, color}) => (
   <span

--- a/docs/api/11_fees/update-fee.mdx
+++ b/docs/api/11_fees/update-fee.mdx
@@ -1,0 +1,271 @@
+---
+sidebar_position: 8
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Update fee
+
+## Route
+
+```curl title="PUT"
+/api/v1/fees/:lago_id
+```
+
+## Usage
+
+<Tabs groupId="prog-language">
+  <TabItem value="curl" label="Curl" default>
+
+  ```bash
+  curl --location --request PUT "$LAGO_URL/api/v1/fees/1a901a90-1a90-1a90-1a90-1a901a901a90" \
+    --header "Authorization: Bearer $API_KEY" \
+    --header 'Content-Type: application/json' \
+    --data-raw '{
+      "fee": {
+        "payment_status": "succeeded"
+      }
+    }'
+  ```
+  </TabItem>
+
+  <TabItem value="python" label="Python">
+
+  ```python
+  from lago_python_client.models import Fee
+
+  fee_update = Fee(
+    payment_status="succeeded",
+  )
+
+  client.fees.update(fee_update, "1a901a90-1a90-1a90-1a90-1a901a901a90")
+  ```
+  </TabItem>
+
+  <TabItem value="ruby" label="Ruby">
+
+  ```ruby
+  client.fees.update({
+    lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a90",
+    payment_status: "succeeded",
+  })
+  ```
+  </TabItem>
+
+  <TabItem value="javascript" label="Javascript">
+
+  ```javascript
+  const feeObject = {
+    payment_status: "succeeded" as FeeObject["payment_status"],
+  };
+
+  await client.fees.updateFee("1a901a90-1a90-1a90-1a90-1a901a901a90", {
+    fee: feeObject,
+  });
+  ```
+  </TabItem>
+
+  <TabItem value="go" label="Go">
+
+  ```go
+  feeId, _ := uuid.Parse("1a901a90-1a90-1a90-1a90-1a901a901a90")
+  feeInput := &lago.FeeInput{
+    LagoID: invoiceId,
+    PaymentStatus: lago.FeePaymentStatusSucceeded,
+  }
+
+  fee, err := lagoClient.Fee().Update(feeInput)
+  if err != nil {
+    panic(err)
+  }
+
+  // fee is *lago.Fee
+  fmt.Println(fee)
+    }
+  ```
+
+  </TabItem>
+
+  <TabItem value="csharp" label="C#">
+
+  ```csharp
+  var apiInstance = new FeesApi(Configuration.Default);
+  var id = "1a901a90-1a90-1a90-1a90-1a901a901a90";
+  var feeInput = new FeeInput();
+
+  try
+  {
+      Fee result = apiInstance.UpdateFee(id, feeInput);
+  }
+  catch (ApiException e)
+  {
+      Debug.Print("Exception when calling lago API: " + e.Message );
+      Debug.Print("Status Code: "+ e.ErrorCode);
+      Debug.Print(e.StackTrace);
+  }
+  ```
+
+  </TabItem>
+  <TabItem value="php" label="PHP">
+
+  ```php
+  $id = "1a901a90-1a90-1a90-1a90-1a901a901a90";
+  $fee_input = new \OpenAPI\Client\Model\FeeInput();
+
+  try {
+      $result = $apiInstance->updateFee($id, $fee_input);
+      print_r($result);
+  } catch (Exception $e) {
+      echo 'Exception when calling lago API: ', $e->getMessage(), PHP_EOL;
+  }
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Arguments
+
+```json
+{
+  "fee": {
+    "payment_status": "succeeded"
+  }
+}
+```
+
+| Attributes | Type | Description |
+|--|--|--|
+| lago_id | String &nbsp &nbsp &nbsp<Required>**Required**</Required> | Fee unique identifier in Lago |
+| payment_status | String &nbsp &nbsp &nbsp<Optional>**Optional**</Optional> | Fee payment status <br></br>It can be `pending`, `succeeded`, `failed` or `refunded` |
+
+:::caution
+Payment status can only be manually updated for `instant_charge` fees.
+:::
+
+## Responses
+
+<Tabs>
+  <TabItem value="200" label="HTTP 200" default>
+  The fee has been successfully updated.
+
+  Returns a [fee](./fee-object) object.
+  </TabItem>
+
+  <TabItem value="400" label="HTTP 400">
+
+  ```json
+  {
+    "status": 400,
+    "error": "Bad Request"
+  }
+  ```
+
+  The `fee` json root is not present in the request body.
+  </TabItem>
+
+  <TabItem value="401" label="HTTP 401">
+
+  ```json
+  {
+    "status": 401,
+    "error": "Unauthorized"
+  }
+  ```
+
+  Access to the API endpoint is unauthorized.
+
+  **Possible reasons are:**
+  * The `Authorization` header is missing
+  * The `Authorization` header does not contain the API key
+  * The Api key is invalid or expired
+
+
+  </TabItem>
+
+  <TabItem value="404" label="HTTP 404">
+
+  ```json
+  {
+    "status": 404,
+    "error": "Not Found",
+    "code": "fee_not_found"
+  }
+  ```
+
+  The `fee` was not found
+  </TabItem>
+
+  <TabItem value="422" label="HTTP 422">
+
+  ```json
+  {
+    "status": 422,
+    "error": "Unprocessable entity",
+    "code": "validation_errors",
+    "error_details": {
+      "field": ["error"]
+    }
+  }
+  ```
+
+  **Possible errors:**
+
+  | Field | Code | Description |
+  |--|--|--|
+  | `payment_status` | `value_is_invalid` | Provided `payment_status` does not match an accepted value |
+
+
+  </TabItem>
+</Tabs>
+
+
+
+export const Required = ({children, color}) => (
+  <span
+    style={{
+      color: "#DC3309",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Optional = ({children, color}) => (
+  <span
+    style={{
+      color: "#8C95A6",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const RequiredUnderCondition = ({children, color}) => (
+  <span
+    style={{
+      color: "#FF7E1D",
+      fontSize: "13px"
+    }}>
+    {children}
+  </span>
+);
+
+export const Comment = ({children, color}) => (
+  <span
+    style={{
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);
+
+export const PostEndpoint = ({children, color}) => (
+  <span
+    style={{
+      color: "#008559",
+      fontSize: "12px"
+    }}>
+    {children}
+  </span>
+);


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the documentation for the new `POST api/v1/events/estimate_fees` route

Related to https://github.com/getlago/lago-api/pull/923
