### PR TITLE
bug(webhook): fix javascript public key snippet

### DIFF
--- a/docs/api/90_webhooks/message-signature.mdx
+++ b/docs/api/90_webhooks/message-signature.mdx
@@ -53,7 +53,9 @@ To verify the signature, you must decode the signature and compare the result wi
   <TabItem value="javascript" label="Javascript">
 
   ```javascript
-  await client.webhooks.fetchPublicKey();
+  const res = yield client.webhooks.fetchPublicKey();
+  const keyText = yield res.text();
+  const webhooksPublicKey = Buffer.from(keyText, "base64").toString("ascii");
   ```
 
 </TabItem>


### PR DESCRIPTION
Javascript client code snippet to retrieve the webhook public key was not explicit enough

The client  response needs to be manipulated in order to be checked

This PR udpated the documentation to make the process explicit