### PR TITLE
feat: Turn balance float amounts into cents

### DIFF
--- a/docs/api/14_wallets/wallet-object.mdx
+++ b/docs/api/14_wallets/wallet-object.mdx
@@ -19,7 +19,7 @@ This object represents a wallet.<br></br>
     "name": "name",
     "rate_amount": "1.5",
     "credits_balance": "10.0",
-    "balance": "10.0",
+    "balance_cents": 1000,
     "consumed_credits": "2.0",
     "created_at": "2022-04-29T08:59:51Z",
     "expiration_at": null,
@@ -39,7 +39,7 @@ This object represents a wallet.<br></br>
 | **name** &nbsp &nbsp <Type>String</Type> | Wallet name. |
 | **rate_amount** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Rate used for conversion between credits and amount in given currency. |
 | **credits_balance** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Balance in credits. |
-| **balance** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Balance in specified currency. |
+| **balance_cents** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Balance in cents in specified currency. |
 | **consumed_credits** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Credits consumed. |
 | **created_at** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> &nbsp &nbsp <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date of wallet creation. |
 | **expiration_at** &nbsp &nbsp <Type>String</Type> <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date and time of wallet expiration. |
@@ -52,6 +52,7 @@ This object represents a wallet.<br></br>
 | Attributes | Description |
 | -----------| ----------- |
 | **expiration_date** &nbsp &nbsp <Type>String</Type> <br></br><Comment>*ISO 8601 datetime in UTC*</Comment> | Date of wallet expiration. |
+| **balance** &nbsp &nbsp <Type>String</Type> | Balance in specified currency |
 
 export const Type = ({children, color}) => (
   <span


### PR DESCRIPTION
## Context

In our data model, amounts are usually integers in cents (e.g. `amount_cents` or `vat_amount_cents`).

However, in wallet, amount attributes are defined in float and exposed as string in the two API

This difference makes it difficult for users to use this information for calculation purposes (e.g. cannot easily deduct `amount_cents` from `balance` without converting the attribute into an integer).

## Description

This PR changes turned wallet fields into bigint and adds currency columns to match the amount and currency handling from other models.
- `balance_cents` / `balance_currency`

For compatibility purpose, all float fields are still exposed in public API but are deprecated.
This changes also requires an update of the front-end to adapt to the new amount fields

Related PR on API: https://github.com/getlago/lago-api/pull/951