### PR TITLE
fix charge-object anchor ref

### DIFF
--- a/docs/api/07_customer_usage/customer-usage-object.mdx
+++ b/docs/api/07_customer_usage/customer-usage-object.mdx
@@ -81,7 +81,7 @@ It allows you to monitor customer usage throughout the period.
 | **units** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Number of units consumed by the customer |
 | **amount_cents** &nbsp &nbsp <Type>Integer</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Amount in cents, VAT (tax) excluded|
 | **amount_currency** &nbsp &nbsp <Type>String</Type>&nbsp &nbsp <NotNullable>Not null</NotNullable> | Currency of the amount |
-| **charge** &nbsp &nbsp <Type>JSON</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Related [charge](#charge) object |
+| **charge** &nbsp &nbsp <Type>JSON</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Related [charge](#charge-object) object |
 | **billable_metric** &nbsp &nbsp <Type>JSON</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Related [billable metric](#billable-metric-object) object |
 | **groups** &nbsp &nbsp <Type>Array</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Array of [group](#group-object) objects |
 


### PR DESCRIPTION
# What
This anchor ref: https://doc.getlago.com/docs/api/customer_usage/customer-usage-object#charge:~:text=Related%20charge%20object is dead because of a typo. This PR fixes it.

![it-aint-much-but-its-honest-work](https://user-images.githubusercontent.com/32591853/232810889-9663eae3-bcca-4636-b3b3-65c1eaa07063.gif)

😜 