### PR TITLE
feat(applied_coupon): coupon name is present in object

### DIFF
--- a/docs/api/09_coupons/apply-coupon.mdx
+++ b/docs/api/09_coupons/apply-coupon.mdx
@@ -340,6 +340,7 @@ For now, it lets you assign a one-off coupon to a customer. This coupon can have
 | **lago_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifer of the applied coupon in Lago application. |
 | **lago_coupon_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifer of the coupon in Lago application. |
 | **coupon_code** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Code identifying the coupon. |
+| **coupon_name** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Name of the coupon. |
 | **external_customer_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifer of the customer in your application. |
 | **lago_customer_id** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Unique identifer of the customer in Lago application. |
 | **status** &nbsp &nbsp <Type>String</Type> &nbsp &nbsp <NotNullable>Not null</NotNullable> | Can be either `active` or `terminated`. |

--- a/docs/api/09_coupons/apply-coupon.mdx
+++ b/docs/api/09_coupons/apply-coupon.mdx
@@ -317,6 +317,7 @@ For now, it lets you assign a one-off coupon to a customer. This coupon can have
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "lago_coupon_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "coupon_code": "coupon-code",
+    "coupon_name": "coupon-name",
     "status": "active",
     "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",


### PR DESCRIPTION
Updates the doc to mention the new exposed attribute of the `applied_coupon` object: `coupon_name`